### PR TITLE
Main Page 정리

### DIFF
--- a/orange/src/components/Articles/Articles.tsx
+++ b/orange/src/components/Articles/Articles.tsx
@@ -5,16 +5,13 @@ function Articles(props: ArticleProps) {
     return (
       <div className={props.className}>
         <article>
-          <h2>프로그래밍 기본 익히기</h2>
+          {/* <h2>프로그래밍 기본 익히기</h2>
           <div className="exercise">
             <h2 className="soft-orange">실습 1.</h2>
             <p>소문자를 입력 받아 대문자 출력하는 프로그램 만들기</p>
             <h2 className="soft-orange">실습 2.</h2>
             <p>골드바흐의 추측을 검증하는 프로그램 만들기(N은 200000 이하)</p>
-          </div>
-        </article>
-        <article>
-          <h2>깃헙 사용하기</h2>
+          </div> */}
         </article>
       </div>
     );

--- a/orange/src/components/Articles/Articles.tsx
+++ b/orange/src/components/Articles/Articles.tsx
@@ -5,13 +5,6 @@ function Articles(props: ArticleProps) {
     return (
       <div className={props.className}>
         <article>
-          {/* <h2>프로그래밍 기본 익히기</h2>
-          <div className="exercise">
-            <h2 className="soft-orange">실습 1.</h2>
-            <p>소문자를 입력 받아 대문자 출력하는 프로그램 만들기</p>
-            <h2 className="soft-orange">실습 2.</h2>
-            <p>골드바흐의 추측을 검증하는 프로그램 만들기(N은 200000 이하)</p>
-          </div> */}
         </article>
       </div>
     );

--- a/orange/src/components/Header/Header.tsx
+++ b/orange/src/components/Header/Header.tsx
@@ -9,7 +9,7 @@ function Header(props: ArticleProps) {
       <header className={props.className}>
         <h1>{props.title}</h1>
         {/* 소개글 넣기 */}
-        <p>Since. 2020.04.12</p>
+        <p>Since. 2020.04.12.</p>
       </header>
     );
 }

--- a/orange/src/components/StudyInfo/StudyInfo.tsx
+++ b/orange/src/components/StudyInfo/StudyInfo.tsx
@@ -9,11 +9,16 @@ function StudyInfo(props: ArticleProps) {
         <section>
           <h2 className="deep-orange">스터디 멤버</h2>
           <ul>
+            <strong>웹 개발 참여</strong>
             <li>다빈</li>
-            <li>민재</li>
             <li>상현</li>
-            <li>은성</li>
+            <li>영현</li>
             <li>진섭</li>
+            <br />
+            <strong>세미나 참여</strong>
+            <li>민재</li>
+            <li>은성</li>
+            <li>재연</li>
           </ul>
         </section>
         <section>


### PR DESCRIPTION
# Major Changes
## 1. Main Page 정리
- 6.28.(일) 모임 이후 이 페이지를 본격적으로 새롭게 활용할 예정이므로, 기존 내용을 정리합니다.
- 기존 Main Page의 article 내용들을 삭제합니다.
- 스터디 멤버의 상황을 업데이트합니다.
