### PR TITLE
local db & cache setting

### DIFF
--- a/nongjang/nongjang/settings.py
+++ b/nongjang/nongjang/settings.py
@@ -13,6 +13,8 @@ https://docs.djangoproject.com/en/3.0/ref/settings/
 import os
 import json
 
+ENV_MODE = os.getenv('MODE', 'dev')
+
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
@@ -80,19 +82,37 @@ secret_file = os.path.join(os.path.dirname(__file__), 'secret_info.json')
 if os.path.exists(secret_file):
     with open(secret_file) as f:
         secret_info = json.loads(f.read())
-        DATABASES = {
-            'default': {
-                'ENGINE': 'django.db.backends.mysql',
-                'NAME': secret_info['DATABASE_NAME'],
-                'USER': secret_info['DATABASE_USER'],
-                'PASSWORD': secret_info['DATABASE_PASSWORD'],
-                'HOST': secret_info['DATABASE_HOST'],
-                'PORT': secret_info['DATABASE_PORT'],
+        if ENV_MODE == 'prod':
+            DATABASES = {
+                'default': {
+                    'ENGINE': 'django.db.backends.mysql',
+                    'NAME': secret_info['DATABASE_NAME'],
+                    'USER': secret_info['DATABASE_USER'],
+                    'PASSWORD': secret_info['DATABASE_PASSWORD'],
+                    'HOST': secret_info['DATABASE_HOST'],
+                    'PORT': secret_info['DATABASE_PORT'],
+                }
             }
-        }
+        else:
+            DATABASES = {
+                'default': {
+                    'ENGINE': 'django.db.backends.mysql',
+                    'NAME': secret_info['DATABASE_NAME'],
+                    'USER': secret_info['DATABASE_USER'],
+                    'PASSWORD': secret_info['DATABASE_PASSWORD'],
+                    'HOST': 'localhost',
+                    'PORT': '3306',
+                }
+            }
 else:
     raise Exception("Check your 'secret_info.json' file!")
 
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+        'TIMEOUT': 3600,
+    }
+}
 
 # Password validation
 # https://docs.djangoproject.com/en/3.0/ref/settings/#auth-password-validators


### PR DESCRIPTION
# Major Changes
## 1. 환경 변수 MODE에 따라 dev와 prod db 연결 분기
- **note: 기본적으로 Linux 또는 MacOS 기준으로 설명하므로, Windows에서는 약간 다른 command가 필요할 수도 있습니다.**
- dev는 개발 환경(지금은 이것이 즉 로컬 환경이지만, 개발 db도 AWS RDS 등으로 원격으로 따로 두는 경우도 많습니다), prod는 실제 서비스(production) 환경을 뜻합니다.
- `python manage.py runserver` 또는 `MODE=dev python manage.py runserver`와 같은 식으로 Django 서버를 실행하면 로컬 MySQL db에 연결합니다. AWS RDS에 연결하기 위해서는 `MODE=prod python manage.py runserver`로 환경 변수에 prod를 두어 서버를 실행합니다.

- 로컬 MySQL에 적절한 password를 가진 user 정보와, 적절한 이름을 가진 database, 그리고 user가 그것에 대한 권한을 가져야 합니다.
  - MySQL 서버가 실행되는 상태임을 확실히 하세요.
    `mysql.server start`
  - 로컬 MySQL cli에 접속하세요. 기본적으로 password가 없는 root 라는 계정이 존재할 가능성이 높습니다.
    `mysql -u root`
  - 아래 명령어는 MySQL cli에서 실행하는 명령입니다. username, password, dbname은 AWS RDS의 그것과 같습니다. 즉, `secret_info.json`과 같은 값들을 사용하면 됩니다. 아래 command에 그것들을 포함시키는 것은 보안 이슈가 있으므로 `{DATABASE_NAME}` 같은 식으로 표기하며, literally 그것을 뜻하는 것이 아닙니다. 값을 둘러싼 실제 필요한 `'`들에 주의하세요.
```
    CREATE DATABASE {DATABASE_NAME};
    CREATE USER '{DATABASE_USER}'@'localhost' IDENTIFIED BY '{DATABASE_PASSWORD}';
    GRANT ALL PRIVILEGES ON {DATABASE_NAME}.* to '{DATABASE_USER}'@'localhost';
```
  - 위의 내용을 MySQL cli에서 수행한 후, `exit;` 를 통해 빠져나와 Django를 로컬 db에 연결되도록 실행했을 때 문제 없이 연결되면 완료입니다.
  - 처음에는 db에 아무 table도 없으므로, migrate 해야 합니다.

* * *

# Minor Changes
## 1. add cache setting
- 당장 필요하진 않지만 어차피 쓰게 될 가능성이 높으므로, cache 세팅을 추가합니다. 일단 dev와 prod 모두에서 동일한 세팅으로 유지합니다.
