### PR TITLE
Add log to Timeline page (no css)

### DIFF
--- a/orange/src/components/LogList/LogList.tsx
+++ b/orange/src/components/LogList/LogList.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+
+interface Props {
+  logs: any;
+}
+
+function LogList(props: Props) {
+  const { username } = props.logs.user;
+  const necessityname = props.logs.necessity.name;
+  const createdAt = (new Date(props.logs.created_at)).toLocaleString();
+
+  const activityCategory = () => {
+    switch (props.logs.activity_category) {
+      case 'CREATE':
+        return '를(을) 생필품 목록에 추가했습니다.';
+      case 'UPDATE':
+        return '를(을) 수정했습니다.';
+      case 'DELETE':
+        return '를(을) 생필품 목록에서 삭제했습니다/';
+      default:
+        return '를(을) 수정했습니다.';
+    }
+  };
+
+  return (
+    <div className="logList">
+      <p>
+        {username}
+        {' '}
+        이(가)
+        {' '}
+        &apos;
+        {necessityname}
+        &apos;
+        {activityCategory()}
+        {' '}
+        (
+        {createdAt}
+        )
+      </p>
+    </div>
+  );
+}
+
+export default LogList;

--- a/orange/src/components/index.tsx
+++ b/orange/src/components/index.tsx
@@ -7,6 +7,7 @@ import NecessityList from './Necessity/NecessityList';
 import NecessityTemplate from './Necessity/NecessityTemplate';
 import SignUpModal from './SignUpModal/SignUpModal';
 import StudyInfo from './StudyInfo/StudyInfo';
+import LogList from './LogList/LogList';
 
 export {
   Header,
@@ -18,4 +19,5 @@ export {
   NecessityTemplate,
   SignUpModal,
   StudyInfo,
+  LogList,
 };

--- a/orange/src/constants/constants.ts
+++ b/orange/src/constants/constants.ts
@@ -13,3 +13,9 @@ export const necessityStatus = {
   FAILURE: 'FAILURE',
   FAILURE_NAME: 'FAILURE_NAME',
 };
+
+export const necessityUserLogStatus = {
+  NONE: 'NONE',
+  SUCCESS: 'SUCCESS',
+  FAILURE: 'FAILURE',
+};

--- a/orange/src/containers/MainPage/MainPage.tsx
+++ b/orange/src/containers/MainPage/MainPage.tsx
@@ -29,7 +29,7 @@ class MainPage extends Component<Props, State> {
         body = <WorkPage />;
         break;
       case 2:
-        body = <TimelinePage />;
+        body = <TimelinePage history={this.props.history} />;
         break;
       case 3:
         body = <StatisticsPage />;

--- a/orange/src/containers/TimelinePage/TimelinePage.tsx
+++ b/orange/src/containers/TimelinePage/TimelinePage.tsx
@@ -1,10 +1,43 @@
 import React, { Component } from 'react';
+import axios from 'axios';
 
-class TimelinePage extends Component {
+import { LogList } from '../../components/index';
+
+interface Props {
+  history?: any;
+}
+
+interface State {
+  logs: any[];
+  getLogAPISuccess: boolean;
+}
+
+class TimelinePage extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = {
+      logs: [],
+      getLogAPISuccess: false,
+    };
+  }
+
+  componentDidMount() {
+    axios.get('/api/v1/necessity/log/')
+      .then((res) => {
+        if (res.status === 200) {
+          this.setState({ logs: res.data, getLogAPISuccess: true });
+        }
+      });
+  }
+
   render() {
+    const { logs, getLogAPISuccess } = this.state;
+    const logList = logs.map((log) => <LogList key={log.id} logs={log} />);
+
     return (
       <div className="timeline-page">
         타임라인 페이지
+        {getLogAPISuccess ? logList : null}
       </div>
     );
   }

--- a/orange/src/containers/TimelinePage/TimelinePage.tsx
+++ b/orange/src/containers/TimelinePage/TimelinePage.tsx
@@ -1,15 +1,16 @@
 import React, { Component } from 'react';
 import axios from 'axios';
 
-import { LogList } from '../../components/index';
+import { LogList } from '../../components';
+import { necessityUserLogStatus } from '../../constants/constants';
 
 interface Props {
-  history?: any;
+  history: any;
 }
 
 interface State {
   logs: any[];
-  getLogAPISuccess: boolean;
+  getLogStatus: string;
 }
 
 class TimelinePage extends Component<Props, State> {
@@ -17,7 +18,7 @@ class TimelinePage extends Component<Props, State> {
     super(props);
     this.state = {
       logs: [],
-      getLogAPISuccess: false,
+      getLogStatus: necessityUserLogStatus.NONE,
     };
   }
 
@@ -25,19 +26,19 @@ class TimelinePage extends Component<Props, State> {
     axios.get('/api/v1/necessity/log/')
       .then((res) => {
         if (res.status === 200) {
-          this.setState({ logs: res.data, getLogAPISuccess: true });
+          this.setState({ logs: res.data, getLogStatus: necessityUserLogStatus.SUCCESS });
         }
       });
   }
 
   render() {
-    const { logs, getLogAPISuccess } = this.state;
+    const { logs, getLogStatus } = this.state;
     const logList = logs.map((log) => <LogList key={log.id} logs={log} />);
 
     return (
       <div className="timeline-page">
         타임라인 페이지
-        {getLogAPISuccess ? logList : null}
+        {getLogStatus === necessityUserLogStatus.SUCCESS ? logList : null}
       </div>
     );
   }


### PR DESCRIPTION
### TimelinePage에서 api/v1/necessity/log GET 호출
* redux를 끼지 않고 componentDidMount에서 호출합니다.
* api 호출 성공 시 response를 전달하여 <LogList /> 를 리턴합니다.

### LogList 컴포넌트에서 user가 necessity를 생성 및 수정한 기록 표시
* " 'user'가 'necessity'를 'activfity_category'했습니다. ('created_at') " 와 같은 형식으로 표시합니다.
* created_at의 값을 toLocaleString()로 변형하여 시간 표시 형태가 못생긴 상태입니다. log 스타일을 꾸밀 때 date 스타일도 변경할 예정입니다.
* css를 넣지 않은 상태입니다.

<img width="1405" alt="Screen Shot 2020-08-18 at 12 27 44 AM" src="https://user-images.githubusercontent.com/54926767/90413604-a5177080-e0e9-11ea-8f17-c93555510ece.png">
