### PR TITLE
Change codes from the latest PR

### DIFF
--- a/nongjang/necessity/serializers.py
+++ b/nongjang/necessity/serializers.py
@@ -24,8 +24,8 @@ class NecessitySerializer(serializers.ModelSerializer):
         except NecessityUser.DoesNotExist:
             raise Exception("no necessity user")
         return {
-            "necessity_user_id": necessity_user.id,
-            "necessity_user_count": necessity_user.count,
+            "id": necessity_user.id,
+            "count": necessity_user.count,
         }
     
 

--- a/nongjang/necessity/views.py
+++ b/nongjang/necessity/views.py
@@ -63,13 +63,14 @@ class NecessityViewSet(viewsets.GenericViewSet):
     def destroy(self, request, pk=None):
         try:
             necessity_user = NecessityUser.objects.get(pk=pk)
-            NecessityUserLog.objects.create(user=necessity_user.user, necessity=necessity_user.necessity,
-                                            activity_category=NecessityUserLog.DELETE)
-            necessity_user.delete()
-            return Response(status=status.HTTP_204_NO_CONTENT)
 
         except NecessityUser.DoesNotExist:
             return Response(status=status.HTTP_404_NOT_FOUND)
+
+        NecessityUserLog.objects.create(user=necessity_user.user, necessity=necessity_user.necessity,
+                                        activity_category=NecessityUserLog.DELETE)
+        necessity_user.delete()
+        return Response(status=status.HTTP_204_NO_CONTENT)
 
     # GET /api/v1/necessity/log/
     @action(methods=['get'], detail=False)

--- a/orange/src/components/Necessity/NecessityItem/NecessityItem.tsx
+++ b/orange/src/components/Necessity/NecessityItem/NecessityItem.tsx
@@ -53,7 +53,7 @@ interface Props {
 function NecessityItem(props: Props) {
   function refreshPage() {
     window.alert('삭제 완료!');
-    window.location.reload(false);
+    window.location.reload();
   }
 
   return (


### PR DESCRIPTION
## Changes

**1. Backend**
- Necessity directory의 Serializer.py에서 NecessitySerializer 클래스 내부 get_necessity_user 함수의 return 값의 key를 기존의 'necessity_user_id', 'necessity_user_count'에서 '**id**', '**count**'로 수정

- Necessity directory의 views.py에서 DELETE API 함수를 일부 수정


<br>

**2. Frontend**
- DELETE API 작동 시 새로고침 함수의 default 값을 굳이 명시하지 않도록 수정.