### PR TITLE
ON-12 [back] Necessity Update API debugging

### DIFF
--- a/nongjang/necessity/views.py
+++ b/nongjang/necessity/views.py
@@ -74,12 +74,12 @@ class NecessityViewSet(viewsets.GenericViewSet):
         necessity_new, created = Necessity.objects.get_or_create(name=name, option=option,
                                                                  description=description, price=price)
 
-        if not created:
-            return Response({'error': "수정된 사항이 없습니다."}, status=status.HTTP_400_BAD_REQUEST)
-        else:
-            # create log when user update necessity
+        if created and necessity_user.necessity_id != necessity_new.id:
+            # create log when user newly update necessity
             NecessityUserLog.objects.create(user=user, necessity=necessity_user.necessity,
                                             activity_category=NecessityUserLog.UPDATE)
+        else:
+            return Response({'error': "수정된 사항이 없습니다."}, status=status.HTTP_400_BAD_REQUEST)
 
         necessity_user.user = user
         necessity_user.necessity = necessity_new

--- a/nongjang/necessity/views.py
+++ b/nongjang/necessity/views.py
@@ -56,7 +56,6 @@ class NecessityViewSet(viewsets.GenericViewSet):
     # PUT /api/v1/necessity/{necessity_user_id}/
     def update(self, request, pk=None, **kwargs):
         user = request.user
-
         name = request.data.get('name')
         if not name:
             return Response({'error': "생필품 이름을 입력하세요."}, status=status.HTTP_400_BAD_REQUEST)
@@ -67,23 +66,25 @@ class NecessityViewSet(viewsets.GenericViewSet):
 
         try:
             necessity_user = NecessityUser.objects.get(pk=pk)
-
         except NecessityUser.DoesNotExist:
             return Response(status=status.HTTP_404_NOT_FOUND)
 
         necessity_new, created = Necessity.objects.get_or_create(name=name, option=option,
                                                                  description=description, price=price)
 
-        if created and necessity_user.necessity_id != necessity_new.id:
+        if created or necessity_user.necessity_id != necessity_new.id:
             # create log when user newly update necessity
             NecessityUserLog.objects.create(user=user, necessity=necessity_user.necessity,
                                             activity_category=NecessityUserLog.UPDATE)
         else:
             return Response({'error': "수정된 사항이 없습니다."}, status=status.HTTP_400_BAD_REQUEST)
 
-        necessity_user.user = user
-        necessity_user.necessity = necessity_new
-        necessity_user.save()
+        try:
+            necessity_user.user = user
+            necessity_user.necessity = necessity_new
+            necessity_user.save()
+        except IntegrityError:
+            return Response({'error': "이미 존재하는 생필품입니다."}, status=status.HTTP_409_CONFLICT)
 
         return Response(self.get_serializer(necessity_user.necessity).data)
 


### PR DESCRIPTION
## Debugging History

참고 : [**Jira ON-12**](https://orangenongjang.atlassian.net/browse/ON-12)

**생필품 수정 기능**
- Necessity Update API([Jira ON-4](https://orangenongjang.atlassian.net/browse/ON-4))에 존재하던 오류 수정
> 기존에는 Necessity Table과 비교하여 중복된 생필품인지 아닌지를 체크했으나 이제는 NecessityUser table의 **necessity_id**와 새롭게 생성되거나 기존에 존재하여 호출된 necessity_new의 **id**를 비교하는 방식을 사용함.

> NecessityUser table에 존재하는 생필품으로 수정하려고 할 때 발생하는 IntegrityError를 **409 Conflict** status code로 처리하여 `'error': "이미 존재하는 생필품입니다."`를 반환하도록 변경함.
