### PR TITLE
ON-15 [front] HousePage & API request with house id

### DIFF
--- a/orange/src/App.tsx
+++ b/orange/src/App.tsx
@@ -3,7 +3,9 @@ import { ConnectedRouter } from 'connected-react-router';
 import { Route, Switch, Redirect } from 'react-router-dom';
 
 import { Header } from './components';
-import { MainPage, IntroPage, InfoPage } from './containers';
+import {
+  MainPage, IntroPage, InfoPage, HousePage,
+} from './containers';
 import './App.css';
 
 interface Props {
@@ -16,9 +18,11 @@ function App(props: Props): JSX.Element {
       <ConnectedRouter history={props.history}>
         <Header history={props.history} />
         <Switch>
-          <Route exact path="/" component={MainPage} history={props.history} />
+          <Route exact path="/" component={HousePage} hisory={props.history} />
+          <Route exact path="/main/:id" component={MainPage} history={props.history} />
           <Route exact path="/intro" component={IntroPage} history={props.history} />
           <Route exact path="/info" component={InfoPage} />
+          <Route exact path="/house" component={HousePage} history={props.history} />
           <Redirect exact to="/intro" />
         </Switch>
       </ConnectedRouter>

--- a/orange/src/components/HouseList/HouseList.tsx
+++ b/orange/src/components/HouseList/HouseList.tsx
@@ -1,0 +1,59 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+
+interface House {
+  id: string;
+  name: string;
+  introduction: string;
+}
+
+interface Props {
+  history: any;
+}
+
+function HouseList(props: Props) {
+  const [houses, setHouses] = useState<[House]>();
+
+  const goInTheRoom = (houseId: string) => {
+    const url = `/main/${houseId}`;
+    props.history.push(url);
+  };
+
+  useEffect(() => {
+    const { CancelToken } = axios;
+    const source = CancelToken.source();
+
+    axios.get('/api/v1/house/', { cancelToken: source.token })
+      .then((res) => setHouses(res.data));
+
+    return () => {
+      source.cancel();
+    };
+  }, []);
+
+  const returnUserHouses = houses?.map((house, index) => (
+    <div key={index}>
+      <h1>
+        {house.name}
+      </h1>
+      <h2>
+        {house.introduction}
+      </h2>
+      <button
+        type="button"
+        onClick={() => goInTheRoom(house.id)}
+      >
+        들어가기
+      </button>
+      <hr />
+    </div>
+  ));
+
+  return (
+    <>
+      { returnUserHouses }
+    </>
+  );
+}
+
+export default HouseList;

--- a/orange/src/components/Necessity/NecessityCreateModal/NecessityCreateModal.tsx
+++ b/orange/src/components/Necessity/NecessityCreateModal/NecessityCreateModal.tsx
@@ -7,10 +7,17 @@ import './NecessityCreateModal.css';
 
 interface Props {
   history: History;
-  create: (name: string, option: string, description: string, price: number) => any;
+  create: (
+    name: string,
+    option: string,
+    description: string,
+    price: number,
+    houseId: string
+  ) => any;
   me: any;
   createStatus: string;
   restoreModal: any;
+  houseId: string;
 }
 
 interface State {
@@ -34,7 +41,13 @@ class NecessityCreateModal extends Component<Props, State> {
   }
 
   create = (): void => {
-    this.props.create(this.state.name, this.state.option, this.state.description, this.state.price)
+    this.props.create(
+      this.state.name,
+      this.state.option,
+      this.state.description,
+      this.state.price,
+      this.props.houseId,
+    )
       .then(() => {
         console.log(this.props.createStatus);
         if (this.props.createStatus === necessityStatus.SUCCESS) {
@@ -128,8 +141,10 @@ class NecessityCreateModal extends Component<Props, State> {
 }
 
 const mapDispatchToProps = (dispatch: Dispatch<any>) => ({
-  create: (name: string, option: string, description: string, price: number): void => dispatch(
-    necessityActions.createNecessity(name, option, description, price),
+  create: (
+    name: string, option: string, description: string, price: number, houseId: string,
+  ): void => dispatch(
+    necessityActions.createNecessity(name, option, description, price, houseId),
   ),
 });
 

--- a/orange/src/components/Necessity/NecessityCreateModal/NecessityCreateModal.tsx
+++ b/orange/src/components/Necessity/NecessityCreateModal/NecessityCreateModal.tsx
@@ -12,12 +12,12 @@ interface Props {
     option: string,
     description: string,
     price: number,
-    houseId: string
+    houseId: number
   ) => any;
   me: any;
   createStatus: string;
   restoreModal: any;
-  houseId: string;
+  houseId: number;
 }
 
 interface State {
@@ -142,7 +142,7 @@ class NecessityCreateModal extends Component<Props, State> {
 
 const mapDispatchToProps = (dispatch: Dispatch<any>) => ({
   create: (
-    name: string, option: string, description: string, price: number, houseId: string,
+    name: string, option: string, description: string, price: number, houseId: number,
   ): void => dispatch(
     necessityActions.createNecessity(name, option, description, price, houseId),
   ),

--- a/orange/src/components/index.tsx
+++ b/orange/src/components/index.tsx
@@ -8,6 +8,7 @@ import NecessityTemplate from './Necessity/NecessityTemplate/NecessityTemplate';
 import SignUpModal from './SignUpModal/SignUpModal';
 import StudyInfo from './StudyInfo/StudyInfo';
 import LogList from './LogList/LogList';
+import HouseList from './HouseList/HouseList';
 
 export {
   Header,
@@ -20,4 +21,5 @@ export {
   SignUpModal,
   StudyInfo,
   LogList,
+  HouseList,
 };

--- a/orange/src/containers/HousePage/HousePage.tsx
+++ b/orange/src/containers/HousePage/HousePage.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+import { HouseList } from '../../components/index';
+
+interface Props {
+  history: any;
+}
+
+function HousePage(props: Props) {
+  return (
+    <HouseList history={props.history} />
+  );
+}
+
+export default HousePage;

--- a/orange/src/containers/MainPage/MainPage.tsx
+++ b/orange/src/containers/MainPage/MainPage.tsx
@@ -8,6 +8,7 @@ import './MainPage.css';
 
 interface Props {
   history: any;
+  match: any;
 }
 
 interface State {
@@ -23,19 +24,21 @@ class MainPage extends Component<Props, State> {
   }
 
   render() {
+    const houseId = this.props.match.params.id;
+
     let body = null;
     switch (this.state.activeTab) {
       case 1:
         body = <WorkPage />;
         break;
       case 2:
-        body = <TimelinePage history={this.props.history} />;
+        body = <TimelinePage history={this.props.history} houseId={houseId} />;
         break;
       case 3:
         body = <StatisticsPage />;
         break;
       default:
-        body = <NecessityPage history={this.props.history} />;
+        body = <NecessityPage history={this.props.history} houseId={houseId} />;
     }
 
     return (

--- a/orange/src/containers/NecessityPage/NecessityPage.tsx
+++ b/orange/src/containers/NecessityPage/NecessityPage.tsx
@@ -47,8 +47,8 @@ const GlobalStyle = createGlobalStyle`
 
 interface Props {
   history: any;
-  get(houseId: string): void;
-  houseId: string;
+  get(houseId: number): void;
+  houseId: number;
 }
 
 function NecessityPage(props: Props): ReactElement {
@@ -99,7 +99,7 @@ function NecessityPage(props: Props): ReactElement {
 }
 
 const mapDispatchToProps = (dispatch: Dispatch<any>) => ({
-  get: (houseId: string): void => dispatch(
+  get: (houseId: number): void => dispatch(
     necessityActions.getNecessity(houseId),
   ),
 });

--- a/orange/src/containers/NecessityPage/NecessityPage.tsx
+++ b/orange/src/containers/NecessityPage/NecessityPage.tsx
@@ -47,7 +47,8 @@ const GlobalStyle = createGlobalStyle`
 
 interface Props {
   history: any;
-  get(): void;
+  get(houseId: string): void;
+  houseId: string;
 }
 
 function NecessityPage(props: Props): ReactElement {
@@ -66,7 +67,7 @@ function NecessityPage(props: Props): ReactElement {
   };
 
   useEffect(() => {
-    props.get();
+    props.get(props.houseId);
   });
 
   return (
@@ -86,6 +87,7 @@ function NecessityPage(props: Props): ReactElement {
             <NecessityCreateModal
               history={props.history}
               restoreModal={restoreModal}
+              houseId={props.houseId}
             />
           ) : null}
 
@@ -97,8 +99,8 @@ function NecessityPage(props: Props): ReactElement {
 }
 
 const mapDispatchToProps = (dispatch: Dispatch<any>) => ({
-  get: (): void => dispatch(
-    necessityActions.getNecessity(),
+  get: (houseId: string): void => dispatch(
+    necessityActions.getNecessity(houseId),
   ),
 });
 

--- a/orange/src/containers/TimelinePage/TimelinePage.tsx
+++ b/orange/src/containers/TimelinePage/TimelinePage.tsx
@@ -24,7 +24,7 @@ class TimelinePage extends Component<Props, State> {
   }
 
   componentDidMount() {
-    axios.get(`/api/v1/necessity/${this.props.houseId}/log/`)
+    axios.get('/api/v1/necessity/log/', { params: this.props.houseId })
       .then((res) => {
         if (res.status === 200) {
           this.setState({ logs: res.data, getLogStatus: necessityUserLogStatus.SUCCESS });

--- a/orange/src/containers/TimelinePage/TimelinePage.tsx
+++ b/orange/src/containers/TimelinePage/TimelinePage.tsx
@@ -6,6 +6,7 @@ import { necessityUserLogStatus } from '../../constants/constants';
 
 interface Props {
   history: any;
+  houseId: string;
 }
 
 interface State {
@@ -23,7 +24,7 @@ class TimelinePage extends Component<Props, State> {
   }
 
   componentDidMount() {
-    axios.get('/api/v1/necessity/log/')
+    axios.get(`/api/v1/necessity/${this.props.houseId}/log/`)
       .then((res) => {
         if (res.status === 200) {
           this.setState({ logs: res.data, getLogStatus: necessityUserLogStatus.SUCCESS });

--- a/orange/src/containers/index.tsx
+++ b/orange/src/containers/index.tsx
@@ -1,9 +1,11 @@
 import MainPage from './MainPage/MainPage';
 import IntroPage from './IntroPage/IntroPage';
 import InfoPage from './InfoPage/InfoPage';
+import HousePage from './HousePage/HousePage';
 
 export {
   InfoPage,
   IntroPage,
   MainPage,
+  HousePage,
 };

--- a/orange/src/store/actions/necessity/necessity.tsx
+++ b/orange/src/store/actions/necessity/necessity.tsx
@@ -85,9 +85,9 @@ const countFailure = (error: any) => {
 };
 
 export const createNecessity = (
-  name: string, option: string, description: string, price: number,
-) => (dispatch: Dispatch) => axios.post('/api/v1/necessity/', {
-  name, option, description, price,
+  name: string, option: string, description: string, price: number, houseId: string,
+) => (dispatch: Dispatch) => axios.post(`/api/v1/${houseId}/necessity/`, {
+  name, option, description, price, houseId,
 })
   .then((createResponse) => dispatch(createSuccess(createResponse.data)))
   .catch((createError) => dispatch(createFailure(createError)));
@@ -96,7 +96,7 @@ export const removeNecessity = (necessityUserId: number) => (dispatch: Dispatch)
   .then((removeResponse) => dispatch(removeSuccess(removeResponse.data)))
   .catch((removeError) => dispatch(removeFailure(removeError)));
 
-export const getNecessity = () => (dispatch: Dispatch) => axios.get('/api/v1/necessity/')
+export const getNecessity = (houseId: string) => (dispatch: Dispatch) => axios.get(`/api/v1/necessity/${houseId}/`)
   .then((getResponse) => dispatch(getSuccess(getResponse.data)))
   .catch((getError) => dispatch(getFailure(getError)));
 

--- a/orange/src/store/actions/necessity/necessity.tsx
+++ b/orange/src/store/actions/necessity/necessity.tsx
@@ -85,8 +85,8 @@ const countFailure = (error: any) => {
 };
 
 export const createNecessity = (
-  name: string, option: string, description: string, price: number, houseId: string,
-) => (dispatch: Dispatch) => axios.post(`/api/v1/${houseId}/necessity/`, {
+  name: string, option: string, description: string, price: number, houseId: number,
+) => (dispatch: Dispatch) => axios.post('/api/v1/necessity/', {
   name, option, description, price, houseId,
 })
   .then((createResponse) => dispatch(createSuccess(createResponse.data)))
@@ -96,7 +96,7 @@ export const removeNecessity = (necessityUserId: number) => (dispatch: Dispatch)
   .then((removeResponse) => dispatch(removeSuccess(removeResponse.data)))
   .catch((removeError) => dispatch(removeFailure(removeError)));
 
-export const getNecessity = (houseId: string) => (dispatch: Dispatch) => axios.get(`/api/v1/necessity/${houseId}/`)
+export const getNecessity = (houseId: number) => (dispatch: Dispatch) => axios.get('/api/v1/necessity/', { params: { houseId } })
   .then((getResponse) => dispatch(getSuccess(getResponse.data)))
   .catch((getError) => dispatch(getFailure(getError)));
 


### PR DESCRIPTION
### 1. HousePage 추가
* 유저의 하우스 목록을 불러옵니다
* 버튼을 누르면 해당 하우스 id를 들고 main으로 이동합니다

### 2. Route 수정
*  '/' route를 MainPage에서 HousePage로 변경했습니다
* 메인 페이지는 '/main/:id' 로 url이 변경되었습니다

### 3. Necessity Create, Necessity Get, Necessity Log API request에 houseId param을 추가

### 수정 및 추가해야 할 것
* 유저의 house가 아닐 경우 /main 에서 다른 페이지(/house 같은)로 이동 시켜야 함
* 하우스 만들기 버튼을 넣어야 함 

현재 하우스 만드는 버튼이 없기 때문에 포스트맨으로 직접 House 만든 후 테스트 부탁드립니다

<img width="1440" alt="Screen Shot 2020-09-09 at 4 08 55 PM" src="https://user-images.githubusercontent.com/54926767/92566182-c4538900-f2b6-11ea-8473-47cdfde7a85e.png">
