### PR TITLE
ON-20 [back] Change logic of validating count and price variable

### DIFF
--- a/nongjang/house/views.py
+++ b/nongjang/house/views.py
@@ -77,7 +77,7 @@ class HouseViewSet(viewsets.GenericViewSet):
         user_house = user.user_houses.filter(house=house).last()
         if not user_house:
             return Response({'error': "소속되어 있지 않은 집입니다."}, status=status.HTTP_403_FORBIDDEN)
-        
+
         if user_house.is_leader:
             return Response({'error': 'leader이므로 집을 떠날 수 없습니다. leader를 다른 유저에게 양도한 뒤 다시 시도해 주세요'},
                             status=status.HTTP_400_BAD_REQUEST)
@@ -127,11 +127,11 @@ class HouseViewSet(viewsets.GenericViewSet):
         description = data.get('description', '')
         price = data.get('price')
         count = data.get('count')
-        if not count or not count.isnumeric() or int(count) < 0:
+        if not count or not isinstance(count, int) or int(count) < 0:
             return Response({'error': "count는 필수 항목이며 0 이상의 정수여야 합니다."}, status=status.HTTP_400_BAD_REQUEST)
         count = int(count)
         if price:
-            if not price.isnumeric() or int(price) < 0:
+            if not isinstance(price, int) or int(price) < 0:
                 return Response({'error': "price는 0 이상의 정수여야 합니다."}, status=status.HTTP_400_BAD_REQUEST)
             price = int(price)
         else:
@@ -174,3 +174,4 @@ class HouseViewSet(viewsets.GenericViewSet):
         logs = NecessityLog.objects.filter(
             necessity_house__house=house).order_by('-created_at').select_related('necessity_house')
         return Response(self.get_serializer(logs, many=True).data)
+

--- a/nongjang/house/views.py
+++ b/nongjang/house/views.py
@@ -109,7 +109,6 @@ class HouseViewSet(viewsets.GenericViewSet):
         user_house = request.user.user_houses.filter(house=house).last()
         if not user_house:
             return Response({'error': "소속되어 있지 않은 집입니다."}, status=status.HTTP_403_FORBIDDEN)
-
         if self.request.method == 'POST':
             return self._create_necessity(house)
         return self._get_necessity(house)
@@ -174,4 +173,3 @@ class HouseViewSet(viewsets.GenericViewSet):
         logs = NecessityLog.objects.filter(
             necessity_house__house=house).order_by('-created_at').select_related('necessity_house')
         return Response(self.get_serializer(logs, many=True).data)
-

--- a/nongjang/house/views.py
+++ b/nongjang/house/views.py
@@ -126,13 +126,23 @@ class HouseViewSet(viewsets.GenericViewSet):
         description = data.get('description', '')
         price = data.get('price')
         count = data.get('count')
-        if not count or not isinstance(count, int) or int(count) < 0:
+
+        if isinstance(count, str):
+            if not count.isnumeric() or int(count) < 0:
+                return Response({'error': "count는 필수 항목이며 0 이상의 정수여야 합니다."}, status=status.HTTP_400_BAD_REQUEST)
+            else:
+                count = int(count)
+        elif not isinstance(count, int) or count < 0:
             return Response({'error': "count는 필수 항목이며 0 이상의 정수여야 합니다."}, status=status.HTTP_400_BAD_REQUEST)
-        count = int(count)
+
         if price:
-            if not isinstance(price, int) or int(price) < 0:
+            if isinstance(price, str):
+                if not price.isnumeric() or int(price) < 0:
+                    return Response({'error': "price는 0 이상의 정수여야 합니다."}, status=status.HTTP_400_BAD_REQUEST)
+                else:
+                    price = int(price)
+            elif not isinstance(price, int) or count < 0:
                 return Response({'error': "price는 0 이상의 정수여야 합니다."}, status=status.HTTP_400_BAD_REQUEST)
-            price = int(price)
         else:
             price = None
 


### PR DESCRIPTION
[Jira ON-20](https://orangenongjang.atlassian.net/browse/ON-20)에 명시한대로 Django code 두 줄 수정하였습니다.

현재 Main branch에서는 생필품 생성 시 [NecessityCreateModal.tsx](https://github.com/gongmyeong-study/orangenongjang/blob/master/orange/src/components/Necessity/NecessityCreateModal/NecessityCreateModal.tsx#L116)에서 price 및 count input 값을 다음과 같이 정의하고 있습니다.

<img width="777" alt="image" src="https://user-images.githubusercontent.com/46114393/96338000-211c3d80-10c6-11eb-9701-b45fa365fe11.png">

이는 프론트엔드에서 price 값으로 1234.5 등의 값을 입력해도 정수로 내림하여 반환하는 함수를 사용한 코드로서, 오류가 있는 상황이기 때문에 추후 [ON-19](https://orangenongjang.atlassian.net/browse/ON-19)에서는 지금의 **parseInt** 대신 **parseFloat**을 사용할 예정입니다. parseFloat을 사용하면 사용자가 1234.5 값을 입력했을 때 백엔드에서 `isinstance(price, int)`를 통해 "**price는 0 이상의 정수여야 합니다.**"라는 문구와 함께 **400 Error**를 반환하게 됩니다.
