### PR TITLE
ON-23 [back] modify urls for creating and updating necessity API

### DIFF
--- a/nongjang/house/serializers.py
+++ b/nongjang/house/serializers.py
@@ -58,4 +58,3 @@ class UserOfHouseSerializer(serializers.ModelSerializer):
             'is_leader',
             'joined_at',
         )
-

--- a/nongjang/house/serializers.py
+++ b/nongjang/house/serializers.py
@@ -14,7 +14,7 @@ class SimpleHouseSerializer(serializers.ModelSerializer):
             'name',
             'introduction',
             'users',
-         )
+        )
 
     def get_users(self, house):
         user_houses = house.user_houses.all().select_related('user')
@@ -58,3 +58,4 @@ class UserOfHouseSerializer(serializers.ModelSerializer):
             'is_leader',
             'joined_at',
         )
+

--- a/nongjang/house/urls.py
+++ b/nongjang/house/urls.py
@@ -12,4 +12,3 @@ urlpatterns = [
     path('house/<int:house_id>/necessity/<int:necessity_id>/', HouseNecessityView.as_view()),
     path('house/<int:house_id>/necessity/<int:necessity_id>/count/', HouseNecessityCountView.as_view()),
 ]
-

--- a/nongjang/house/urls.py
+++ b/nongjang/house/urls.py
@@ -1,6 +1,6 @@
 from django.urls import include, path
 from rest_framework.routers import SimpleRouter
-from house.views import HouseViewSet
+from house.views import HouseViewSet, HouseNecessityView, HouseNecessityCountView
 
 app_name = 'house'
 
@@ -9,4 +9,7 @@ router.register('house', HouseViewSet, basename='house')  # /api/v1/house/
 
 urlpatterns = [
     path('', include((router.urls))),
+    path('house/<int:house_id>/necessity/<int:necessity_id>/', HouseNecessityView.as_view()),
+    path('house/<int:house_id>/necessity/<int:necessity_id>/count/', HouseNecessityCountView.as_view()),
 ]
+

--- a/nongjang/house/views.py
+++ b/nongjang/house/views.py
@@ -291,4 +291,3 @@ class HouseNecessityCountView(APIView):
         necessity_house.save()
 
         return Response(NecessityOfHouseSerializer(necessity_house).data)
-

--- a/nongjang/house/views.py
+++ b/nongjang/house/views.py
@@ -3,11 +3,12 @@ from rest_framework import status, viewsets
 from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
+from rest_framework.views import APIView
 
 from house.models import House, UserHouse
 from house.serializers import HouseSerializer, SimpleHouseSerializer
 from necessity.models import Necessity, NecessityHouse, NecessityLog
-from necessity.serializers import NecessityLogSerializer
+from necessity.serializers import NecessityLogSerializer, NecessityOfHouseSerializer
 
 
 class HouseViewSet(viewsets.GenericViewSet):
@@ -141,7 +142,7 @@ class HouseViewSet(viewsets.GenericViewSet):
                     return Response({'error': "price는 0 이상의 정수여야 합니다."}, status=status.HTTP_400_BAD_REQUEST)
                 else:
                     price = int(price)
-            elif not isinstance(price, int) or count < 0:
+            elif not isinstance(price, int) or price < 0:
                 return Response({'error': "price는 0 이상의 정수여야 합니다."}, status=status.HTTP_400_BAD_REQUEST)
         else:
             price = None
@@ -183,3 +184,111 @@ class HouseViewSet(viewsets.GenericViewSet):
         logs = NecessityLog.objects.filter(
             necessity_house__house=house).order_by('-created_at').select_related('necessity_house')
         return Response(self.get_serializer(logs, many=True).data)
+
+
+class HouseNecessityView(APIView):
+    permission_classes = (IsAuthenticated, )
+
+    # PUT /api/v1/house/{house_id}/necessity/{necessity_id}/
+    def put(self, request, *args, **kwargs):
+        house_id = kwargs['house_id']
+        necessity_id = kwargs['necessity_id']
+
+        user = request.user
+
+        try:
+            necessity_house = NecessityHouse.objects.get(house_id=house_id, necessity_id=necessity_id)
+        except NecessityHouse.DoesNotExist:
+            return Response(status=status.HTTP_404_NOT_FOUND)
+
+        if not user.user_houses.filter(house=necessity_house.house).exists():
+            return Response({'error': "소속되어 있지 않은 집의 Necessity입니다."}, status=status.HTTP_403_FORBIDDEN)
+
+        data = request.data
+        name = data.get('name')
+        description = data.get('description')
+        price = data.get('price')
+        updated = False
+
+        if price:
+            if isinstance(price, str):
+                if not price.isnumeric() or int(price) < 0:
+                    return Response({'error': "price는 0 이상의 정수여야 합니다."}, status=status.HTTP_400_BAD_REQUEST)
+                else:
+                    necessity_house.price = int(price)
+                    updated = True
+            elif not isinstance(price, int) or price < 0:
+                return Response({'error': "price는 0 이상의 정수여야 합니다."}, status=status.HTTP_400_BAD_REQUEST)
+        else:
+            necessity_house.price = None
+            updated = True
+
+        if name:
+            necessity_house.name = name
+            updated = True
+
+        if description is not None:
+            necessity_house.description = description
+            updated = True
+
+        if updated:
+            necessity_house.save()
+
+        NecessityLog.objects.create(necessity_house=necessity_house, user=user, action=NecessityLog.UPDATE)
+
+        return Response(NecessityOfHouseSerializer(necessity_house).data)
+
+    # DELETE /api/v1/house/{house_id}/necessity/{necessity_id}/
+    def delete(self, request, *args, **kwargs):
+        house_id = kwargs['house_id']
+        necessity_id = kwargs['necessity_id']
+
+        user = request.user
+
+        try:
+            necessity_house = NecessityHouse.objects.get(house_id=house_id, necessity_id=necessity_id)
+        except NecessityHouse.DoesNotExist:
+            return Response(status=status.HTTP_404_NOT_FOUND)
+
+        if not user.user_houses.filter(house=necessity_house.house).exists():
+            return Response({'error': "소속되어 있지 않은 집의 Necessity입니다."}, status=status.HTTP_403_FORBIDDEN)
+
+        NecessityLog.objects.create(necessity_house=necessity_house, user=user, action=NecessityLog.DELETE)
+        necessity_house.count = 0
+        necessity_house.save()
+
+        return Response(NecessityOfHouseSerializer(necessity_house).data)
+
+
+class HouseNecessityCountView(APIView):
+    permission_classes = (IsAuthenticated, )
+
+    # PUT /api/v1/house/{house_id}/necessity/{necessity_id}/count/
+    def put(self, request, *args, **kwargs):
+        house_id = kwargs['house_id']
+        necessity_id = kwargs['necessity_id']
+
+        user = request.user
+
+        count = request.data.get('count')
+        if isinstance(count, str):
+            if not count.isnumeric() or int(count) < 0:
+                return Response({'error': "count는 필수 항목이며 0 이상의 정수여야 합니다."}, status=status.HTTP_400_BAD_REQUEST)
+            else:
+                count = int(count)
+        elif not isinstance(count, int) or count < 0:
+            return Response({'error': "count는 필수 항목이며 0 이상의 정수여야 합니다."}, status=status.HTTP_400_BAD_REQUEST)
+
+        try:
+            necessity_house = NecessityHouse.objects.get(house_id=house_id, necessity_id=necessity_id)
+        except NecessityHouse.DoesNotExist:
+            return Response(status=status.HTTP_404_NOT_FOUND)
+
+        if not user.user_houses.filter(house=necessity_house.house).exists():
+            return Response({'error': "소속되어 있지 않은 집의 Necessity입니다."}, status=status.HTTP_403_FORBIDDEN)
+
+        necessity_house.count = count
+        necessity_house.save()
+
+        return Response(NecessityOfHouseSerializer(necessity_house).data)
+

--- a/nongjang/necessity/serializers.py
+++ b/nongjang/necessity/serializers.py
@@ -23,17 +23,25 @@ class NecessityOfHouseSerializer(serializers.ModelSerializer):
     option = serializers.CharField(source='necessity.option')
     description = serializers.SerializerMethodField()
     price = serializers.SerializerMethodField()
+    house_id = serializers.SerializerMethodField()
 
     class Meta:
         model = NecessityHouse
         fields = (
             'id',
+            'house_id',
             'name',
             'option',
             'description',
             'price',
             'count',
         )
+
+    def get_house_id(self, necessity_house):
+        if necessity_house.house_id:
+            return necessity_house.house_id
+        else:
+            return None
 
     def get_description(self, necessity_house):
         return necessity_house.description if necessity_house.description else necessity_house.necessity.description

--- a/nongjang/necessity/serializers.py
+++ b/nongjang/necessity/serializers.py
@@ -19,11 +19,11 @@ class NecessitySerializer(serializers.ModelSerializer):
 
 class NecessityOfHouseSerializer(serializers.ModelSerializer):
     id = serializers.IntegerField(source='necessity.id')
+    house_id = serializers.IntegerField(source='house.id')
     name = serializers.CharField(source='necessity.name')
     option = serializers.CharField(source='necessity.option')
     description = serializers.SerializerMethodField()
     price = serializers.SerializerMethodField()
-    house_id = serializers.SerializerMethodField()
 
     class Meta:
         model = NecessityHouse
@@ -36,12 +36,6 @@ class NecessityOfHouseSerializer(serializers.ModelSerializer):
             'price',
             'count',
         )
-
-    def get_house_id(self, necessity_house):
-        if necessity_house.house_id:
-            return necessity_house.house_id
-        else:
-            return None
 
     def get_description(self, necessity_house):
         return necessity_house.description if necessity_house.description else necessity_house.necessity.description

--- a/nongjang/necessity/urls.py
+++ b/nongjang/necessity/urls.py
@@ -10,4 +10,3 @@ router.register('necessity', NecessityViewSet, basename='necessity')  # /api/v1/
 urlpatterns = [
     path('', include((router.urls))),
 ]
-

--- a/nongjang/necessity/urls.py
+++ b/nongjang/necessity/urls.py
@@ -1,13 +1,13 @@
 from django.urls import include, path
 from rest_framework.routers import SimpleRouter
-from necessity.views import NecessityViewSet, NecessityHouseViewSet
+from necessity.views import NecessityViewSet
 
 app_name = 'necessity'
 
 router = SimpleRouter()
 router.register('necessity', NecessityViewSet, basename='necessity')  # /api/v1/necessity/
-router.register('necessity_house', NecessityHouseViewSet, basename='necessity-house')  # /api/v1/necessity_house/
 
 urlpatterns = [
     path('', include((router.urls))),
 ]
+

--- a/nongjang/necessity/views.py
+++ b/nongjang/necessity/views.py
@@ -1,11 +1,10 @@
 from django.db import IntegrityError
 from rest_framework import status, viewsets
-from rest_framework.decorators import action
 from rest_framework.permissions import IsAdminUser, IsAuthenticated
 from rest_framework.response import Response
 
-from necessity.serializers import NecessitySerializer, NecessityOfHouseSerializer
-from necessity.models import Necessity, NecessityHouse, NecessityLog
+from necessity.serializers import NecessitySerializer
+from necessity.models import Necessity
 
 
 class NecessityViewSet(viewsets.GenericViewSet):
@@ -56,4 +55,3 @@ class NecessityViewSet(viewsets.GenericViewSet):
     # GET /api/v1/necessity/
     def list(self, request):
         return Response(self.get_serializer(self.get_queryset(), many=True).data)
-

--- a/nongjang/necessity/views.py
+++ b/nongjang/necessity/views.py
@@ -3,8 +3,8 @@ from rest_framework import status, viewsets
 from rest_framework.permissions import IsAdminUser, IsAuthenticated
 from rest_framework.response import Response
 
-from necessity.serializers import NecessitySerializer
 from necessity.models import Necessity
+from necessity.serializers import NecessitySerializer
 
 
 class NecessityViewSet(viewsets.GenericViewSet):


### PR DESCRIPTION
## Major Changes
#### 0. 개요
- necessity/views.py에서 관리되던 (user들의) 생필품 생성 및 수정, 수량 증감 API를 house/views.py에서 담당하도록 수정하였습니다. 이에 따라 새로운 url을 정의할 필요가 있어 기존의  GenericViewSet 대신 개별 APIView를 override했기 때문에 get_object, get_serializer 등의 함수를 상속할 수 없게 됩니다.

#### 1. 생필품 생성 및 수정 API url 변경
- [PUT, DELETE] `/api/v1/necessity_house/{necessity_house_id}/ `
-> [PUT, DELETE] `/api/v1/house/{house_id}/necessity/{necessity_id}/`

#### 2. 생필품 수량 증감 API url 변경
- [PUT] `/api/v1/necessity_house/{necessity_house_id}/count/`
-> [PUT] `/api/v1/house/{house_id}/necessity/{necessity_id}/count/`
 

<br>

## Minor Changes
- [ON-20](https://github.com/gongmyeong-study/orangenongjang/pull/49)에서 count 및 price가 str인 경우(postman을 통해 직접 API를 시행시키는 경우)와 int인 경우(frontend에서 값을 정수로 제한하여 backend로 보낸 경우) 모두를 고려한 코드를 바탕으로 생필품 수정 및 수량 증감 API 코드를 개선하였습니다.
