### PR TITLE
ON-8 [back] Ordering for NecessityList & NecessityLog API

### DIFF
--- a/nongjang/house/serializers.py
+++ b/nongjang/house/serializers.py
@@ -40,7 +40,7 @@ class HouseSerializer(serializers.ModelSerializer):
         return UserOfHouseSerializer(user_houses, many=True, context=self.context).data
 
     def get_necessities(self, house):
-        order = self.context['request'].query_params['order']
+        order = self.context['request'].query_params.get('order')
         queryset = house.necessity_houses.filter(count__gt=0)
         if order == 'name':
             necessity_houses = queryset.order_by('necessity__name', '-created_at').select_related('necessity')

--- a/nongjang/house/serializers.py
+++ b/nongjang/house/serializers.py
@@ -40,9 +40,9 @@ class HouseSerializer(serializers.ModelSerializer):
         return UserOfHouseSerializer(user_houses, many=True, context=self.context).data
 
     def get_necessities(self, house):
-        order = self.context['request'].query_params.get('order')
+        necessity_order = self.context['request'].query_params.get('necessity_order')
         queryset = house.necessity_houses.filter(count__gt=0)
-        if order == 'name':
+        if necessity_order == 'name':
             necessity_houses = queryset.order_by('necessity__name', '-created_at').select_related('necessity')
         else:
             necessity_houses = queryset.order_by('-created_at').select_related('necessity')

--- a/nongjang/house/serializers.py
+++ b/nongjang/house/serializers.py
@@ -40,8 +40,13 @@ class HouseSerializer(serializers.ModelSerializer):
         return UserOfHouseSerializer(user_houses, many=True, context=self.context).data
 
     def get_necessities(self, house):
-        necessity_houses = house.necessity_houses.filter(
-            count__gt=0).order_by('-updated_at').select_related('necessity')
+        order = self.context['request'].query_params['order']
+        queryset = house.necessity_houses.filter(count__gt=0)
+        if order == 'name':
+            necessity_houses = queryset.order_by('necessity__name', '-created_at').select_related('necessity')
+        else:
+            necessity_houses = queryset.order_by('-created_at').select_related('necessity')
+
         return NecessityOfHouseSerializer(necessity_houses, many=True, context=self.context).data
 
 

--- a/nongjang/house/views.py
+++ b/nongjang/house/views.py
@@ -176,13 +176,21 @@ class HouseViewSet(viewsets.GenericViewSet):
     # GET /api/v1/house/{house_id}/necessity_log/
     @action(detail=True, methods=['GET'])
     def necessity_log(self, request, pk=None):
+        log_order = self.request.GET.get('order', None)
         house = self.get_object()
         user_house = request.user.user_houses.filter(house=house).last()
         if not user_house:
             return Response({'error': "소속되어 있지 않은 집입니다."}, status=status.HTTP_403_FORBIDDEN)
 
-        logs = NecessityLog.objects.filter(
-            necessity_house__house=house).order_by('-created_at').select_related('necessity_house')
+        if log_order == 'earliest':
+            logs = NecessityLog.objects.filter(
+                necessity_house__house=house).order_by('created_at').select_related('necessity_house')
+        elif log_order == 'user':
+            logs = NecessityLog.objects.filter(
+                necessity_house__house=house).order_by('user_id', '-created_at').select_related('necessity_house')
+        else:
+            logs = NecessityLog.objects.filter(
+                necessity_house__house=house).order_by('-created_at').select_related('necessity_house')
         return Response(self.get_serializer(logs, many=True).data)
 
 

--- a/nongjang/house/views.py
+++ b/nongjang/house/views.py
@@ -289,5 +289,6 @@ class HouseNecessityCountView(APIView):
 
         necessity_house.count = count
         necessity_house.save()
+        NecessityLog.objects.create(action='COUNT', necessity_house_id=necessity_house.id, user_id=user.id)
 
         return Response(NecessityOfHouseSerializer(necessity_house).data)

--- a/nongjang/house/views.py
+++ b/nongjang/house/views.py
@@ -185,8 +185,6 @@ class HouseViewSet(viewsets.GenericViewSet):
         queryset = NecessityLog.objects.filter(necessity_house__house=house).select_related('necessity_house')
         if log_order == 'earliest':
             logs = queryset.order_by('created_at')
-        elif log_order == 'user':
-            logs = queryset.order_by('user_id', '-created_at')
         else:
             logs = queryset.order_by('-created_at')
         return Response(self.get_serializer(logs, many=True).data)


### PR DESCRIPTION
## Major Changes [ON-8](https://orangenongjang.atlassian.net/browse/ON-8)
#### 1. NecessityLog 생성
- [GET] `/api/v1/house/{house_id}/necessity_log/ `
- 생필품 수량 변경 시 Log 생성
- NecessityLog 정렬 방식에 기존의 '최신순'에 '사용자순'을 추가하여 사용자의 이름을 오름차순으로 하여 생필품 관리 기록을 확인 가능.

<br>

#### 2. Necessity 조회
- [GET] `/api/v1/house/{houseId}/necessity/`
- 생필품 나열 순서를 기존의 '변경순'에서 '최신순', '이름순'으로 변경함.
 
<br>

### Related Tasks
- [ON-9](https://orangenongjang.atlassian.net/browse/ON-9) 바로 작업 시작할 예정.