### PR TITLE
ON-31 [back] count 0과 삭제를 유저 입장에서 분리

### DIFF
--- a/nongjang/house/serializers.py
+++ b/nongjang/house/serializers.py
@@ -40,12 +40,16 @@ class HouseSerializer(serializers.ModelSerializer):
         return UserOfHouseSerializer(user_houses, many=True, context=self.context).data
 
     def get_necessities(self, house):
-        necessity_order = self.context['request'].query_params.get('necessity_order')
-        queryset = house.necessity_houses.filter(count__gt=0)
+        queryset = house.necessity_houses.select_related('necessity')
+
+        necessity_order = None
+        if self.context.get('request'):
+            necessity_order = self.context['request'].query_params.get('necessity_order')
+
         if necessity_order == 'name':
-            necessity_houses = queryset.order_by('necessity__name', '-created_at').select_related('necessity')
+            necessity_houses = queryset.order_by('necessity__name', '-created_at')
         else:
-            necessity_houses = queryset.order_by('-created_at').select_related('necessity')
+            necessity_houses = queryset.order_by('-created_at')
 
         return NecessityOfHouseSerializer(necessity_houses, many=True, context=self.context).data
 

--- a/orange/src/components/Necessity/NecessityCreateModal/NecessityCreateModal.tsx
+++ b/orange/src/components/Necessity/NecessityCreateModal/NecessityCreateModal.tsx
@@ -108,10 +108,6 @@ class NecessityCreateModal extends Component<Props, State> {
               step="1"
               placeholder="1"
               required
-              onChange={(e) => this.setState({
-                count: (parseFloat(e.target.value) === parseInt(e.target.value, 10))
-                  ? parseFloat(e.target.value) : NaN,
-              })}
             />
 
             <label htmlFor="option">

--- a/orange/src/store/reducers/necessity/necessity.tsx
+++ b/orange/src/store/reducers/necessity/necessity.tsx
@@ -18,8 +18,7 @@ const initialState: NecessityState = {
 
 function necessityreducer(state = initialState, action: Action): NecessityState {
   let necessityHouse: NecessityHouse;
-  if (action.type === necessityConstants.COUNT_SUCCESS
-    || action.type === necessityConstants.REMOVE_SUCCESS) {
+  if (action.type === necessityConstants.COUNT_SUCCESS) {
     necessityHouse = { ...state.necessityHouse };
     const data = action.target as Necessity;
     const indexToBeUpdated = necessityHouse.necessities.findIndex(({ id }) => id === data.id);


### PR DESCRIPTION
related issues: https://orangenongjang.atlassian.net/browse/ON-31, https://orangenongjang.atlassian.net/browse/ON-25

# Major Changes
## 1. count 0과 삭제를 유저 입장에서 분리
- count 0인 상태인 NecessityHouse가 존재하도록 변경 (특정 생필품이 다 떨어진 순간 등)
- 삭제를 하면 NecessityHouse 해당 row가 실제로 삭제됨

## 2. 삭제시 해당 웹 페이지를 refresh해야 삭제 이후가 반영되는 상황 수정
- `DELETE /api/v1/house/{house_id}/necessity/{necessity_id}/` 의 response를 `GET /api/v1/house/{house_id}/necessity/` 와 동일한 형태로 삭제 이후의 해당 집 생필품들의 list를 포함하도록 함
- 이에 관련한 React reducer 관련 한 줄 수정

* * *

# Minor Changes
## 1. ON-25 작업 전까지 DB에 기 존재하는 생필품을 집에 생성하려고 요청하는 경우 409 발생하지 않도록 함
- `POST /api/v1/house/{house_id}/necessity/` 에서, frontend가 DB에 기 존재하는 생필품으로 요청하려는 경우 해당 necessity_id를 전달해야 함.
- 그러나 ON-25 작업 전까지, frontend가 NecessityHouse의 Necessity로서 택하고 싶은 necessity_id를 알 방법이 없음. 따라서 그 전까지 임시 방편인 조치를 취하고 FIXME로 표시함.
