### PR TITLE
ON-30 [front] Fix a bug about NecessityLog and make it grammatically natural 

### DIFF
--- a/orange/src/components/LogList/LogList.tsx
+++ b/orange/src/components/LogList/LogList.tsx
@@ -11,15 +11,17 @@ function LogList(props: Props) {
   const createdAt = (new Date(props.logs.created_at)).toLocaleString();
 
   const activityCategory = () => {
-    switch (props.logs.activity_category) {
+    switch (props.logs.action) {
       case 'CREATE':
-        return '를(을) 생필품 목록에 추가했습니다.';
+        return '을(를) 생필품 목록에 추가했습니다.';
       case 'UPDATE':
-        return '를(을) 수정했습니다.';
+        return '을(를) 수정했습니다.';
       case 'DELETE':
-        return '를(을) 생필품 목록에서 삭제했습니다.';
+        return '을(를) 생필품 목록에서 삭제했습니다.';
+      case 'COUNT':
+        return '의 수량을 변경했습니다.';
       default:
-        return '를(을) 수정했습니다.';
+        return '을(를) 수정했습니다.';
     }
   };
 


### PR DESCRIPTION
## Main Change
- 어떤 Action이든 상관 없이 모두 switch case의 default인 "를(을) 수정하였습니다."로 타던 기존의 방식을 수정. (props.logs.action_category가 아닌 props.logs.action로 변경)

- NecessityCount 수행 시 action을 추가했습니다.

<br>

### Minor Change
- "를(을)" 조사 대신 "을(를)"로 바꾸었습니다.

