### PR TITLE
ON-28 [front] material ui form with hook

### DIFF
--- a/orange/package.json
+++ b/orange/package.json
@@ -4,6 +4,8 @@
   "private": true,
   "proxy": "http://localhost:8000",
   "dependencies": {
+    "@material-ui/core": "^4.11.0",
+    "@material-ui/icons": "^4.9.1",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",
@@ -25,6 +27,7 @@
     "lodash": "4.17.19",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
+    "react-hook-form": "^6.11.2",
     "react-icons": "^3.10.0",
     "react-redux": "^7.2.0",
     "react-router-dom": "^5.1.5",

--- a/orange/src/App.tsx
+++ b/orange/src/App.tsx
@@ -21,7 +21,7 @@ function App(props: Props): JSX.Element {
         <Switch>
           <Route exact path="/" component={HousePage} hisory={props.history} />
           <Route exact path="/main/:id" component={MainPage} history={props.history} />
-          <Route exact path="/intro" component={IntroPage} history={props.history} />
+          <Route exact path="/intro" component={IntroPage} />
           <Route exact path="/info" component={InfoPage} />
           <Route exact path="/house" component={HousePage} history={props.history} />
           <Redirect exact to="/intro" />

--- a/orange/src/components/Login/Login.tsx
+++ b/orange/src/components/Login/Login.tsx
@@ -1,83 +1,67 @@
-import React, { Component, Dispatch } from 'react';
-import { connect } from 'react-redux';
-import { History } from 'history';
+import React from 'react';
+import TextField from '@material-ui/core/TextField';
+import AccountCircle from '@material-ui/icons/AccountCircle';
+import LockIcon from '@material-ui/icons/Lock';
+import InputAdornment from '@material-ui/core/InputAdornment';
+import { useForm } from 'react-hook-form';
 
-import { userStatus } from '../../constants/constants';
-import { userActions } from '../../store/actions';
+import { Button } from '@material-ui/core';
 import './Login.css';
-import { OrangeGlobalState } from '../../store/state';
 
 interface Props {
-  history: History;
-  loginStatus: string;
   onLogin: (username: string, password: string) => any;
 }
 
-interface State {
+interface LoginFormData {
   username: string;
   password: string;
 }
 
-class Login extends Component<Props, State> {
-  // NOTE: this Login Component is just for example about api call.
-  //       it can be changed completely differently.
-  constructor(props: Props) {
-    super(props);
-    this.state = {
-      username: '',
-      password: '',
-    };
-  }
+function Login(props: Props) {
+  const {
+    register, handleSubmit, errors,
+  } = useForm<LoginFormData>();
 
-  clickLoginHandler() {
-    this.props.onLogin(this.state.username, this.state.password)
-      .then(() => {
-        if (this.props.loginStatus === userStatus.SUCCESS) {
-          this.props.history.push('/');
-          window.location.reload();
-        } else {
-          alert('로그인에 실패하였습니다. \n이름과 비밀번호를 확인해 주세요!');
-        }
-      });
-  }
+  const onSubmit = (data: LoginFormData) => props.onLogin(data.username, data.password);
 
-  render() {
-    return (
-      <>
-        <h1>Login</h1>
-        <div className="LoginField">
-          <input
-            id="username"
-            type="text"
-            placeholder="username"
-            onChange={(e) => this.setState({ username: e.target.value })}
-          />
-          <input
-            id="password"
-            type="password"
-            placeholder="password"
-            onChange={(e) => this.setState({ password: e.target.value })}
-          />
-        </div>
-        <button
-          type="button"
-          className="LoginButton"
-          disabled={!this.state.username || !this.state.password}
-          onClick={() => this.clickLoginHandler()}
-        >
-          go
-        </button>
-      </>
-    );
-  }
+  return (
+    <>
+      <form onSubmit={handleSubmit(onSubmit)}>
+        <TextField
+          name="username"
+          placeholder="이름"
+          InputProps={{
+            startAdornment: (
+              <InputAdornment position="start">
+                <AccountCircle />
+              </InputAdornment>
+            ),
+          }}
+          variant="outlined"
+          inputRef={register({ required: true })}
+          error={Boolean(errors.username)}
+          helperText={errors.username && '이름을 입력해주세요!'}
+        />
+        <TextField
+          name="password"
+          placeholder="비밀번호"
+          InputProps={{
+            startAdornment: (
+              <InputAdornment position="start">
+                <LockIcon />
+              </InputAdornment>
+            ),
+          }}
+          type="password"
+          variant="outlined"
+          inputRef={register({ required: true })}
+          error={Boolean(errors.password)}
+          helperText={errors.password && '비밀번호를 입력해주세요!'}
+        />
+        <Button type="submit">로그인</Button>
+      </form>
+    </>
+  );
 }
 
-const mapStateToProps = (state: OrangeGlobalState) => ({
-  loginStatus: state.user.loginStatus,
-});
-
-const mapDispatchToProps = (dispatch: Dispatch<any>) => ({
-  onLogin: (username: string, password: string) => dispatch(userActions.login(username, password)),
-});
-
-export default connect(mapStateToProps, mapDispatchToProps)(Login);
+export default Login;

--- a/orange/src/components/SignUpModal/SignUpModal.tsx
+++ b/orange/src/components/SignUpModal/SignUpModal.tsx
@@ -42,7 +42,7 @@ function SignUpModal(props: Props) {
           inputRef={register({
             required: { value: true, message: '이메일을 입력해주세요!' },
             pattern: {
-              // eslint-disable-next-line
+              // eslint-disable-next-line no-useless-escape
               value: /^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$/g,
               message: '이메일 형식에 맞지 않습니다!',
             },

--- a/orange/src/components/SignUpModal/SignUpModal.tsx
+++ b/orange/src/components/SignUpModal/SignUpModal.tsx
@@ -1,138 +1,90 @@
-import React, { Component, Dispatch } from 'react';
-import { connect } from 'react-redux';
-import { History } from 'history';
-import { userActions } from '../../store/actions';
-import { userStatus } from '../../constants/constants';
+import React from 'react';
 import './SignUpModal.css';
-import { User } from '../../api';
-import { OrangeGlobalState } from '../../store/state';
+import { useForm } from 'react-hook-form';
+import { Button, InputAdornment, TextField } from '@material-ui/core';
+import AccountCircle from '@material-ui/icons/AccountCircle';
+import LockIcon from '@material-ui/icons/Lock';
+import MailOutlineIcon from '@material-ui/icons/MailOutline';
 
 interface Props {
-  history?: History;
-  signUp: (email: string, username: string, password: string) => any; // for redux dispatch
-  me: User;
-  signupStatus: string;
+  onSignUp: (email: string, username: string, password: string) => any; // for redux dispatch
 }
 
-interface State {
-  appearing: boolean; // for modal appearing
+interface SignUpFormData {
   email: string;
   username: string;
   password: string;
 }
 
-class SignUpModal extends Component<Props, State> {
-  constructor(props: Props) {
-    super(props);
-    this.state = {
-      appearing: true,
-      email: '',
-      username: '',
-      password: '',
-    };
-  }
+function SignUpModal(props: Props) {
+  const {
+    register, handleSubmit, errors,
+  } = useForm<SignUpFormData>();
 
-  signUp = () => {
-    this.props.signUp(this.state.email, this.state.username, this.state.password)
-      .then(() => {
-        if (this.props.signupStatus === userStatus.SUCCESS) {
-          window.alert('성공!');
-          this.setState({ appearing: false });
-          this.props.history?.push('/');
-        } else if (this.props.signupStatus === userStatus.FAILURE_USERNAME) {
-          window.alert('중복된 사용자 이름!');
-        } else {
-          window.alert('실패!');
-        }
-      });
-  };
+  const onSubmit = (data: SignUpFormData) => props.onSignUp(
+    data.email, data.username, data.password,
+  );
 
-  render() {
-    return (
-      <div
-        className="modal"
-        style={this.state.appearing ? { display: 'block' } : { display: 'none' }}
-      >
-        <form>
-          <button
-            type="submit"
-            className="close"
-            title="Close Modal"
-            style={{ background: 'none', border: 'none' }}
-          >
-            &times;
-          </button>
-        </form>
-        <form className="modal-content">
-          <div className="container">
-            <p>오렌지 농장을 이용하기 전에 회원가입을 해주세요</p>
-            <hr />
-            <label htmlFor="email">
-              <b>이메일 (Email)</b>
-            </label>
-            <input
-              type="text"
-              placeholder="haksaeng@snu.ac.kr"
-              required
-              onChange={(e) => this.setState({ email: e.target.value })}
-            />
-
-            <label htmlFor="email">
-              <b>이름 (Name)</b>
-            </label>
-            <input
-              type="text"
-              placeholder="Jinsup"
-              required
-              onChange={(e) => this.setState({ username: e.target.value })}
-            />
-
-            <label htmlFor="psw">
-              <b>비밀번호 (Password)</b>
-            </label>
-            <input
-              type="password"
-              placeholder="Enter Password"
-              required
-              onChange={(e) => this.setState({ password: e.target.value })}
-            />
-
-            {/* <label htmlFor="psw-repeat">
-              <b>비밀번호 확인 (Repeat Password)</b>
-            </label>
-            <input
-              type="password"
-              placeholder="Repeat Password"
-              name="psw-repeat"
-              required
-            /> */}
-
-            <div className="clearfix">
-              <button
-                type="button"
-                className="signupbtn"
-                disabled={this.state.email === '' || this.state.password === '' || this.state.username === ''}
-                onClick={this.signUp}
-              >
-                회원가입
-              </button>
-            </div>
-          </div>
-        </form>
-      </div>
-    );
-  }
+  return (
+    <>
+      <form onSubmit={handleSubmit(onSubmit)}>
+        <TextField
+          name="email"
+          placeholder="이메일"
+          InputProps={{
+            startAdornment: (
+              <InputAdornment position="start">
+                <MailOutlineIcon />
+              </InputAdornment>
+            ),
+          }}
+          variant="outlined"
+          inputRef={register({
+            required: { value: true, message: '이메일을 입력해주세요!' },
+            pattern: {
+              // eslint-disable-next-line
+              value: /^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$/g,
+              message: '이메일 형식에 맞지 않습니다!',
+            },
+          })}
+          error={Boolean(errors.email)}
+          helperText={errors.email && errors.email.message}
+        />
+        <TextField
+          name="username"
+          placeholder="이름"
+          InputProps={{
+            startAdornment: (
+              <InputAdornment position="start">
+                <AccountCircle />
+              </InputAdornment>
+            ),
+          }}
+          variant="outlined"
+          inputRef={register({ required: true })}
+          error={Boolean(errors.username)}
+          helperText={errors.username && '이름을 입력해주세요!'}
+        />
+        <TextField
+          name="password"
+          placeholder="비밀번호"
+          InputProps={{
+            startAdornment: (
+              <InputAdornment position="start">
+                <LockIcon />
+              </InputAdornment>
+            ),
+          }}
+          type="password"
+          variant="outlined"
+          inputRef={register({ required: true })}
+          error={Boolean(errors.password)}
+          helperText={errors.password && '비밀번호를 입력해주세요!'}
+        />
+        <Button type="submit">회원가입</Button>
+      </form>
+    </>
+  );
 }
 
-const mapDispatchToProps = (dispatch: Dispatch<any>) => ({
-  signUp: (email: string, username: string, password: string) => dispatch(
-    userActions.signUp(email, username, password),
-  ),
-});
-
-const mapStateToProps = (state: OrangeGlobalState) => ({
-  signupStatus: state.user.signupStatus,
-  me: state.user.me,
-});
-
-export default connect(mapStateToProps, mapDispatchToProps)(SignUpModal);
+export default SignUpModal;

--- a/orange/src/containers/IntroPage/IntroPage.tsx
+++ b/orange/src/containers/IntroPage/IntroPage.tsx
@@ -1,18 +1,35 @@
-import React, { useState } from 'react';
-import { History } from 'history';
+import React, { useEffect, useState } from 'react';
+import {
+  useSelector, useDispatch,
+} from 'react-redux';
 
 import { Login, SignUpModal } from '../../components/index';
+import { OrangeGlobalState } from '../../store/state';
+import { userStatus } from '../../constants/constants';
+import { login } from '../../store/actions/user/user';
 
-interface Props {
-  history: History;
-}
-
-function IntroPage(props: Props) {
+function IntroPage() {
   const [showSignUpModal, setShowSignUpModal] = useState(false);
   const showModal = () => setShowSignUpModal(true);
+
+  const dispatch = useDispatch();
+  const loginStatus = useSelector((state: OrangeGlobalState) => state.user.loginStatus);
+
+  const onLogin = (username: string, password: string) => {
+    dispatch(login(username, password));
+  };
+
+  useEffect(() => {
+    if (loginStatus === userStatus.SUCCESS) {
+      window.location.reload();
+    } if (loginStatus === userStatus.FAILURE) {
+      alert('로그인에 실패하였습니다. \n이름과 비밀번호를 확인해 주세요!');
+    }
+  }, [loginStatus]);
+
   return (
     <div>
-      <Login history={props.history} />
+      <Login onLogin={onLogin} />
       <button
         onClick={showModal}
         type="button"
@@ -20,7 +37,7 @@ function IntroPage(props: Props) {
         회원가입
         {' '}
       </button>
-      {showSignUpModal ? <SignUpModal history={props.history} /> : null}
+      {showSignUpModal && <SignUpModal /> }
     </div>
   );
 }

--- a/orange/src/containers/IntroPage/IntroPage.tsx
+++ b/orange/src/containers/IntroPage/IntroPage.tsx
@@ -6,17 +6,21 @@ import {
 import { Login, SignUpModal } from '../../components/index';
 import { OrangeGlobalState } from '../../store/state';
 import { userStatus } from '../../constants/constants';
-import { login } from '../../store/actions/user/user';
+import { login, signUp } from '../../store/actions/user/user';
 
 function IntroPage() {
   const [showSignUpModal, setShowSignUpModal] = useState(false);
   const showModal = () => setShowSignUpModal(true);
 
   const dispatch = useDispatch();
-  const loginStatus = useSelector((state: OrangeGlobalState) => state.user.loginStatus);
+  const { loginStatus, signupStatus } = useSelector((state: OrangeGlobalState) => state.user);
 
   const onLogin = (username: string, password: string) => {
     dispatch(login(username, password));
+  };
+
+  const onSignUp = (email: string, username: string, password: string) => {
+    dispatch(signUp(email, username, password));
   };
 
   useEffect(() => {
@@ -25,7 +29,13 @@ function IntroPage() {
     } if (loginStatus === userStatus.FAILURE) {
       alert('로그인에 실패하였습니다. \n이름과 비밀번호를 확인해 주세요!');
     }
-  }, [loginStatus]);
+
+    if (signupStatus === userStatus.SUCCESS) {
+      window.location.reload();
+    } if (signupStatus === userStatus.FAILURE) {
+      alert('회원가입에 실패하였습니다.');
+    }
+  }, [loginStatus, signupStatus]);
 
   return (
     <div>
@@ -37,7 +47,7 @@ function IntroPage() {
         회원가입
         {' '}
       </button>
-      {showSignUpModal && <SignUpModal /> }
+      {showSignUpModal && <SignUpModal onSignUp={onSignUp} /> }
     </div>
   );
 }

--- a/orange/yarn.lock
+++ b/orange/yarn.lock
@@ -1117,6 +1117,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.3.1", "@babel/runtime@^7.4.4", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.7":
+  version "7.12.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.5.tgz#410e7e487441e1b360c29be715d870d9b985882e"
+  integrity sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.10.4", "@babel/template@^7.4.0", "@babel/template@^7.8.6":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.10.4.tgz#3251996c4200ebc71d1a8fc405fba940f36ba278"
@@ -1167,6 +1174,11 @@
   version "10.1.0"
   resolved "https://registry.yarnpkg.com/@csstools/normalize.css/-/normalize.css-10.1.0.tgz#f0950bba18819512d42f7197e56c518aa491cf18"
   integrity sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg==
+
+"@emotion/hash@^0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.8.0.tgz#bbbff68978fefdbe68ccb533bc8cbe1d1afb5413"
+  integrity sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==
 
 "@emotion/is-prop-valid@^0.8.8":
   version "0.8.8"
@@ -1379,6 +1391,77 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^15.0.0"
     chalk "^3.0.0"
+
+"@material-ui/core@^4.11.0":
+  version "4.11.0"
+  resolved "https://registry.yarnpkg.com/@material-ui/core/-/core-4.11.0.tgz#b69b26e4553c9e53f2bfaf1053e216a0af9be15a"
+  integrity sha512-bYo9uIub8wGhZySHqLQ833zi4ZML+XCBE1XwJ8EuUVSpTWWG57Pm+YugQToJNFsEyiKFhPh8DPD0bgupz8n01g==
+  dependencies:
+    "@babel/runtime" "^7.4.4"
+    "@material-ui/styles" "^4.10.0"
+    "@material-ui/system" "^4.9.14"
+    "@material-ui/types" "^5.1.0"
+    "@material-ui/utils" "^4.10.2"
+    "@types/react-transition-group" "^4.2.0"
+    clsx "^1.0.4"
+    hoist-non-react-statics "^3.3.2"
+    popper.js "1.16.1-lts"
+    prop-types "^15.7.2"
+    react-is "^16.8.0"
+    react-transition-group "^4.4.0"
+
+"@material-ui/icons@^4.9.1":
+  version "4.9.1"
+  resolved "https://registry.yarnpkg.com/@material-ui/icons/-/icons-4.9.1.tgz#fdeadf8cb3d89208945b33dbc50c7c616d0bd665"
+  integrity sha512-GBitL3oBWO0hzBhvA9KxqcowRUsA0qzwKkURyC8nppnC3fw54KPKZ+d4V1Eeg/UnDRSzDaI9nGCdel/eh9AQMg==
+  dependencies:
+    "@babel/runtime" "^7.4.4"
+
+"@material-ui/styles@^4.10.0":
+  version "4.10.0"
+  resolved "https://registry.yarnpkg.com/@material-ui/styles/-/styles-4.10.0.tgz#2406dc23aa358217aa8cc772e6237bd7f0544071"
+  integrity sha512-XPwiVTpd3rlnbfrgtEJ1eJJdFCXZkHxy8TrdieaTvwxNYj42VnnCyFzxYeNW9Lhj4V1oD8YtQ6S5Gie7bZDf7Q==
+  dependencies:
+    "@babel/runtime" "^7.4.4"
+    "@emotion/hash" "^0.8.0"
+    "@material-ui/types" "^5.1.0"
+    "@material-ui/utils" "^4.9.6"
+    clsx "^1.0.4"
+    csstype "^2.5.2"
+    hoist-non-react-statics "^3.3.2"
+    jss "^10.0.3"
+    jss-plugin-camel-case "^10.0.3"
+    jss-plugin-default-unit "^10.0.3"
+    jss-plugin-global "^10.0.3"
+    jss-plugin-nested "^10.0.3"
+    jss-plugin-props-sort "^10.0.3"
+    jss-plugin-rule-value-function "^10.0.3"
+    jss-plugin-vendor-prefixer "^10.0.3"
+    prop-types "^15.7.2"
+
+"@material-ui/system@^4.9.14":
+  version "4.9.14"
+  resolved "https://registry.yarnpkg.com/@material-ui/system/-/system-4.9.14.tgz#4b00c48b569340cefb2036d0596b93ac6c587a5f"
+  integrity sha512-oQbaqfSnNlEkXEziDcJDDIy8pbvwUmZXWNqlmIwDqr/ZdCK8FuV3f4nxikUh7hvClKV2gnQ9djh5CZFTHkZj3w==
+  dependencies:
+    "@babel/runtime" "^7.4.4"
+    "@material-ui/utils" "^4.9.6"
+    csstype "^2.5.2"
+    prop-types "^15.7.2"
+
+"@material-ui/types@^5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@material-ui/types/-/types-5.1.0.tgz#efa1c7a0b0eaa4c7c87ac0390445f0f88b0d88f2"
+  integrity sha512-7cqRjrY50b8QzRSYyhSpx4WRw2YuO0KKIGQEVk5J8uoz2BanawykgZGoWEqKm7pVIbzFDN0SpPcVV4IhOFkl8A==
+
+"@material-ui/utils@^4.10.2", "@material-ui/utils@^4.9.6":
+  version "4.10.2"
+  resolved "https://registry.yarnpkg.com/@material-ui/utils/-/utils-4.10.2.tgz#3fd5470ca61b7341f1e0468ac8f29a70bf6df321"
+  integrity sha512-eg29v74P7W5r6a4tWWDAAfZldXIzfyO1am2fIsC39hdUUHm/33k6pGOKPbgDjg/U/4ifmgAePy/1OjkKN6rFRw==
+  dependencies:
+    "@babel/runtime" "^7.4.4"
+    prop-types "^15.7.2"
+    react-is "^16.8.0"
 
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
@@ -1724,6 +1807,13 @@
   integrity sha512-HzOyJb+wFmyEhyfp4D4NYrumi+LQgQL/68HvJO+q6XtuHSDvw6Aqov7sCAhjbNq3bUPgPqbdvjXC5HeB2oEAPg==
   dependencies:
     "@types/history" "*"
+    "@types/react" "*"
+
+"@types/react-transition-group@^4.2.0":
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.0.tgz#882839db465df1320e4753e6e9f70ca7e9b4d46d"
+  integrity sha512-/QfLHGpu+2fQOqQaXh8MG9q03bFENooTb/it4jr5kKaZlDQfWvjqWZg48AwzPVMBHlRuTRAY7hRHCEOXz5kV6w==
+  dependencies:
     "@types/react" "*"
 
 "@types/react@*", "@types/react@^16.9.0":
@@ -3198,6 +3288,11 @@ clone-deep@^4.0.1:
     kind-of "^6.0.2"
     shallow-clone "^3.0.0"
 
+clsx@^1.0.4:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.1.1.tgz#98b3134f9abbdf23b2663491ace13c5c03a73188"
+  integrity sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==
+
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
@@ -3668,6 +3763,14 @@ css-tree@1.0.0-alpha.39:
     mdn-data "2.0.6"
     source-map "^0.6.1"
 
+css-vendor@^2.0.8:
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/css-vendor/-/css-vendor-2.0.8.tgz#e47f91d3bd3117d49180a3c935e62e3d9f7f449d"
+  integrity sha512-x9Aq0XTInxrkuFeHKbYC7zWY8ai7qJ04Kxd9MnvbC1uO5DagxoHQjm4JvG+vCdXOoFtCjbL2XSZfxmoYa9uQVQ==
+  dependencies:
+    "@babel/runtime" "^7.8.3"
+    is-in-browser "^1.0.2"
+
 css-what@2.1:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.3.tgz#a6d7604573365fe74686c3f311c56513d88285f2"
@@ -3794,6 +3897,11 @@ cssstyle@^1.0.0, cssstyle@^1.1.1:
   integrity sha512-GBrLZYZ4X4x6/QEoBnIrqb8B/f5l4+8me2dkom/j1Gtbxy0kBv6OGzKuAsGM75bkGwGAFkt56Iwg28S3XTZgSA==
   dependencies:
     cssom "0.3.x"
+
+csstype@^2.5.2:
+  version "2.6.13"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.13.tgz#a6893015b90e84dd6e85d0e3b442a1e84f2dbe0f"
+  integrity sha512-ul26pfSQTZW8dcOnD2iiJssfXw0gdNVX9IJDH/X3K5DGPfj+fUYe3kB+swUY6BF3oZDxaID3AJt+9/ojSAE05A==
 
 csstype@^3.0.2:
   version "3.0.2"
@@ -4060,6 +4168,14 @@ dom-converter@^0.2:
   integrity sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==
   dependencies:
     utila "~0.4"
+
+dom-helpers@^5.0.1:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-5.2.0.tgz#57fd054c5f8f34c52a3eeffdb7e7e93cd357d95b"
+  integrity sha512-Ru5o9+V8CpunKnz5LGgWXkmrH/20cGKwcHwS4m73zIvs54CN9epEmT/HLqFJW3kXpakAFkEdzgy1hzlJe3E4OQ==
+  dependencies:
+    "@babel/runtime" "^7.8.7"
+    csstype "^3.0.2"
 
 dom-serializer@0:
   version "0.2.2"
@@ -5402,7 +5518,7 @@ hmac-drbg@^1.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.0:
+hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -5583,6 +5699,11 @@ husky@^4.3.0:
     please-upgrade-node "^3.2.0"
     slash "^3.0.0"
     which-pm-runs "^1.0.0"
+
+hyphenate-style-name@^1.0.3:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz#691879af8e220aea5750e8827db4ef62a54e361d"
+  integrity sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ==
 
 iconv-lite@0.4.24, iconv-lite@^0.4.24:
   version "0.4.24"
@@ -5979,6 +6100,11 @@ is-glob@^4.0.0, is-glob@^4.0.1, is-glob@~4.0.1:
   integrity sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==
   dependencies:
     is-extglob "^2.1.1"
+
+is-in-browser@^1.0.2, is-in-browser@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/is-in-browser/-/is-in-browser-1.1.3.tgz#56ff4db683a078c6082eb95dad7dc62e1d04f835"
+  integrity sha1-Vv9NtoOgeMYILrldrX3GLh0E+DU=
 
 is-number@^3.0.0:
   version "3.0.0"
@@ -6734,6 +6860,76 @@ jsprim@^1.2.2:
     extsprintf "1.3.0"
     json-schema "0.2.3"
     verror "1.10.0"
+
+jss-plugin-camel-case@^10.0.3:
+  version "10.4.0"
+  resolved "https://registry.yarnpkg.com/jss-plugin-camel-case/-/jss-plugin-camel-case-10.4.0.tgz#46c75ff7fd61c304984c21af5817823f0f501ceb"
+  integrity sha512-9oDjsQ/AgdBbMyRjc06Kl3P8lDCSEts2vYZiPZfGAxbGCegqE4RnMob3mDaBby5H9vL9gWmyyImhLRWqIkRUCw==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    hyphenate-style-name "^1.0.3"
+    jss "10.4.0"
+
+jss-plugin-default-unit@^10.0.3:
+  version "10.4.0"
+  resolved "https://registry.yarnpkg.com/jss-plugin-default-unit/-/jss-plugin-default-unit-10.4.0.tgz#2b10f01269eaea7f36f0f5fd1cfbfcc76ed42854"
+  integrity sha512-BYJ+Y3RUYiMEgmlcYMLqwbA49DcSWsGgHpVmEEllTC8MK5iJ7++pT9TnKkKBnNZZxTV75ycyFCR5xeLSOzVm4A==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    jss "10.4.0"
+
+jss-plugin-global@^10.0.3:
+  version "10.4.0"
+  resolved "https://registry.yarnpkg.com/jss-plugin-global/-/jss-plugin-global-10.4.0.tgz#19449425a94e4e74e113139b629fd44d3577f97d"
+  integrity sha512-b8IHMJUmv29cidt3nI4bUI1+Mo5RZE37kqthaFpmxf5K7r2aAegGliAw4hXvA70ca6ckAoXMUl4SN/zxiRcRag==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    jss "10.4.0"
+
+jss-plugin-nested@^10.0.3:
+  version "10.4.0"
+  resolved "https://registry.yarnpkg.com/jss-plugin-nested/-/jss-plugin-nested-10.4.0.tgz#017d0c02c0b6b454fd9d7d3fc33470a15eea9fd1"
+  integrity sha512-cKgpeHIxAP0ygeWh+drpLbrxFiak6zzJ2toVRi/NmHbpkNaLjTLgePmOz5+67ln3qzJiPdXXJB1tbOyYKAP4Pw==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    jss "10.4.0"
+    tiny-warning "^1.0.2"
+
+jss-plugin-props-sort@^10.0.3:
+  version "10.4.0"
+  resolved "https://registry.yarnpkg.com/jss-plugin-props-sort/-/jss-plugin-props-sort-10.4.0.tgz#7110bf0b6049cc2080b220b506532bf0b70c0e07"
+  integrity sha512-j/t0R40/2fp+Nzt6GgHeUFnHVY2kPGF5drUVlgkcwYoHCgtBDOhTTsOfdaQFW6sHWfoQYgnGV4CXdjlPiRrzwA==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    jss "10.4.0"
+
+jss-plugin-rule-value-function@^10.0.3:
+  version "10.4.0"
+  resolved "https://registry.yarnpkg.com/jss-plugin-rule-value-function/-/jss-plugin-rule-value-function-10.4.0.tgz#7cff4a91e84973536fa49b6ebbdbf7f339b01c82"
+  integrity sha512-w8504Cdfu66+0SJoLkr6GUQlEb8keHg8ymtJXdVHWh0YvFxDG2l/nS93SI5Gfx0fV29dO6yUugXnKzDFJxrdFQ==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    jss "10.4.0"
+    tiny-warning "^1.0.2"
+
+jss-plugin-vendor-prefixer@^10.0.3:
+  version "10.4.0"
+  resolved "https://registry.yarnpkg.com/jss-plugin-vendor-prefixer/-/jss-plugin-vendor-prefixer-10.4.0.tgz#2a78f3c5d57d1e024fe7ad7c41de34d04e72ecc0"
+  integrity sha512-DpF+/a+GU8hMh/948sBGnKSNfKkoHg2p9aRFUmyoyxgKjOeH9n74Ht3Yt8lOgdZsuWNJbPrvaa3U4PXKwxVpTQ==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    css-vendor "^2.0.8"
+    jss "10.4.0"
+
+jss@10.4.0, jss@^10.0.3:
+  version "10.4.0"
+  resolved "https://registry.yarnpkg.com/jss/-/jss-10.4.0.tgz#473a6fbe42e85441020a07e9519dac1e8a2e79ca"
+  integrity sha512-l7EwdwhsDishXzqTc3lbsbyZ83tlUl5L/Hb16pHCvZliA9lRDdNBZmHzeJHP0sxqD0t1mrMmMR8XroR12JBYzw==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    csstype "^3.0.2"
+    is-in-browser "^1.1.3"
+    tiny-warning "^1.0.2"
 
 jsx-ast-utils@^2.2.1, jsx-ast-utils@^2.2.3:
   version "2.4.1"
@@ -8091,6 +8287,11 @@ pnp-webpack-plugin@1.6.4:
   dependencies:
     ts-pnp "^1.1.6"
 
+popper.js@1.16.1-lts:
+  version "1.16.1-lts"
+  resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.16.1-lts.tgz#cf6847b807da3799d80ee3d6d2f90df8a3f50b05"
+  integrity sha512-Kjw8nKRl1m+VrSFCoVGPph93W/qrSO7ZkqPpTf7F4bk/sqcfWK019dWBUpE/fBOsOQY1dks/Bmcbfn1heM/IsA==
+
 portfinder@^1.0.25:
   version "1.0.28"
   resolved "https://registry.yarnpkg.com/portfinder/-/portfinder-1.0.28.tgz#67c4622852bd5374dd1dd900f779f53462fac778"
@@ -9062,6 +9263,11 @@ react-error-overlay@^6.0.7:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.7.tgz#1dcfb459ab671d53f660a991513cb2f0a0553108"
   integrity sha512-TAv1KJFh3RhqxNvhzxj6LeT5NWklP6rDr2a0jaTfsZ5wSZWHOGeqQyejUp3xxLfPt2UpyJEcVQB/zyPcmonNFA==
 
+react-hook-form@^6.11.2:
+  version "6.11.2"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-6.11.2.tgz#a0d81f71f85551457aa06892599aa07605f42154"
+  integrity sha512-3Go23kq3JAsUi5xNtOBi2YVJALufmycyS8eA/hdriAbj3U7/lffPlcl0QWviSy4L0EE+dsQwEX2YSTyMMADQsw==
+
 react-icons@^3.10.0:
   version "3.10.0"
   resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-3.10.0.tgz#6c217a2dde2e8fa8d293210023914b123f317297"
@@ -9069,7 +9275,7 @@ react-icons@^3.10.0:
   dependencies:
     camelcase "^5.0.0"
 
-react-is@^16.12.0, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.9.0:
+react-is@^16.12.0, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.9.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -9173,6 +9379,16 @@ react-scripts@3.4.1:
     workbox-webpack-plugin "4.3.1"
   optionalDependencies:
     fsevents "2.1.2"
+
+react-transition-group@^4.4.0:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.1.tgz#63868f9325a38ea5ee9535d828327f85773345c9"
+  integrity sha512-Djqr7OQ2aPUiYurhPalTrVy9ddmFCCzwhqQmtN+J3+3DzLO209Fdr70QrN8Z3DsglWql6iY1lDWAfpFiBtuKGw==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    dom-helpers "^5.0.1"
+    loose-envify "^1.4.0"
+    prop-types "^15.6.2"
 
 react@^16.13.1:
   version "16.13.1"
@@ -10560,7 +10776,7 @@ tiny-invariant@^1.0.2:
   resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.1.0.tgz#634c5f8efdc27714b7f386c35e6760991d230875"
   integrity sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw==
 
-tiny-warning@^1.0.0, tiny-warning@^1.0.3:
+tiny-warning@^1.0.0, tiny-warning@^1.0.2, tiny-warning@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
   integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==


### PR DESCRIPTION
### 로그인, 회원가입 컴포넌트에 material ui form + react-hook-form + react redux form 도입
* form ui는 material ui로, validtaion은 react-hook-form으로 하도록 로그인, 회원가입 컴포넌트를 변경했습니다
* redux 연결을 react redux hook 방식으로 하는 등 함수형 컴포넌트에 맞게 hook 방식으로 수정했습니다
* 발목을 잡던게 dispatch 호출로 변경된 state에 따라 history.push하는 부분이었는데, useEffect 안이나 바깥에 넣으면 무한루프가 발생합니다. 임시방편으로 push가 아닌 reload로 처리했는데, 나중에 세련된 방법으로 수정하겠습니다. (history.push할 때 route state가 바뀌는걸 잘 잡으면 될 것 같은데..) 

*이 PR에서는 디자인이 아닌 기능 변화를 담았습니다. form과 hook을 사용하는 예제가 되길 바랍니다
*create necessity에도 새로운 form을 도입하려고 했는데, 생각보다 리팩토링할 부분이 많이 보여서 디자인 작업하면서 다 뜯어고쳐야 할 것 같습니다
