### PR TITLE
ON-43 [back] Fix url and add redirection

### DIFF
--- a/nongjang/user/text.py
+++ b/nongjang/user/text.py
@@ -5,10 +5,7 @@ ENV_MODE = os.getenv('MODE', 'dev')
 
 
 def user_invite_message(domain, uidb64, token):
-    if ENV_MODE == 'dev':
-        link = "http://{}/api/v1/user/{}/activate/{}/".format(domain, uidb64, token)
-    else:
-        link = "http://{}/user/{}/activate/{}/".format(domain, uidb64, token)
+    link = "http://{}/api/v1/user/{}/activate/{}/".format(domain, uidb64, token)
 
     return f"아래 링크를 클릭하면 회원 인증이 완료됩니다.\n\n" \
            f"링크 : {link}\n\n" \

--- a/nongjang/user/text.py
+++ b/nongjang/user/text.py
@@ -4,9 +4,10 @@ import os
 ENV_MODE = os.getenv('MODE', 'dev')
 
 
-def user_invite_message(domain, uidb64, token):
+def user_invite_message(domain, uidb64, token, user):
     link = f"http://{domain}/api/v1/user/{uidb64}/activate/{token}/"
 
-    return f"아래 링크를 클릭하면 회원 인증이 완료됩니다.\n\n" \
+    return f"{user} 님께\n\n\n\n" \
+           f"아래 링크를 클릭하면 회원 인증이 완료됩니다.\n\n" \
            f"링크 : {link}\n\n" \
            f"오렌지농장에 오신 것을 환영합니다 :)"

--- a/nongjang/user/text.py
+++ b/nongjang/user/text.py
@@ -5,7 +5,7 @@ ENV_MODE = os.getenv('MODE', 'dev')
 
 
 def user_invite_message(domain, uidb64, token):
-    link = "http://{}/api/v1/user/{}/activate/{}/".format(domain, uidb64, token)
+    link = f"http://{domain}/api/v1/user/{uidb64}/activate/{token}/"
 
     return f"아래 링크를 클릭하면 회원 인증이 완료됩니다.\n\n" \
            f"링크 : {link}\n\n" \

--- a/nongjang/user/views.py
+++ b/nongjang/user/views.py
@@ -111,9 +111,6 @@ class UserActivateView(viewsets.GenericViewSet):
             if user_activation_token.check_token(user, token):
                 user.is_active = True
                 user.save()
-                return Response({'message': "회원 인증을 성공했습니다"})
+                return redirect(REDIRECT_PAGE)
         except KeyError:
             return Response({'error': "인증 키에 문제가 생겼습니다. 다시 시도해주세요."}, status=status.HTTP_400_BAD_REQUEST)
-
-        redirect(REDIRECT_PAGE)
-        return Response(self.get_serializer(user).data)

--- a/nongjang/user/views.py
+++ b/nongjang/user/views.py
@@ -1,4 +1,3 @@
-from django.contrib import auth
 from django.contrib.auth import authenticate, login, logout
 from django.contrib.auth.models import User
 from django.contrib.sites.shortcuts import get_current_site
@@ -8,7 +7,6 @@ from django.db import IntegrityError
 from django.shortcuts import redirect
 from django.utils.encoding import force_bytes, force_text
 from django.utils.http import urlsafe_base64_decode, urlsafe_base64_encode
-from django.views import View
 from rest_framework import status, viewsets
 from rest_framework.decorators import action
 from rest_framework.response import Response
@@ -16,8 +14,8 @@ from smtplib import SMTPException
 
 from nongjang.settings import REDIRECT_PAGE
 from user.serializers import UserSerializer
-from .token import user_activation_token
 from user.text import user_invite_message
+from .token import user_activation_token
 
 
 class UserViewSet(viewsets.GenericViewSet):
@@ -46,11 +44,9 @@ class UserViewSet(viewsets.GenericViewSet):
             try:
                 EmailMessage("오렌지농장에 초대합니다.", message, to=[email]).send()
                 redirect(REDIRECT_PAGE)
-                return Response({'message': "회원가입 인증 메일이 전송되었습니다"})
             except SMTPException:
                 return Response({'error': "Email 발송에 문제가 있습니다. 다시 시도해주세요."},
                                 status=status.HTTP_503_SERVICE_UNAVAILABLE)
-        return Response(self.get_serializer(user).data, status=status.HTTP_201_CREATED)
 
     # PUT /api/v1/user/login/
     @action(detail=False, methods=['PUT'])
@@ -111,6 +107,9 @@ class UserActivateView(viewsets.GenericViewSet):
             if user_activation_token.check_token(user, token):
                 user.is_active = True
                 user.save()
-                return redirect(REDIRECT_PAGE)
+            else:
+                return Response({'error': "유효하지 않은 키입니다."}, status=status.HTTP_400_BAD_REQUEST)
         except KeyError:
             return Response({'error': "인증 키에 문제가 생겼습니다. 다시 시도해주세요."}, status=status.HTTP_400_BAD_REQUEST)
+        redirect(REDIRECT_PAGE)
+        return Response(self.get_serializer(user).data)

--- a/nongjang/user/views.py
+++ b/nongjang/user/views.py
@@ -40,10 +40,11 @@ class UserViewSet(viewsets.GenericViewSet):
             domain = get_current_site(request).domain
             uidb64 = urlsafe_base64_encode(force_bytes(user.pk))
             token = user_activation_token.make_token(user)
-            message = user_invite_message(domain, uidb64, token)
+            message = user_invite_message(domain, uidb64, token, user)
             try:
                 EmailMessage("오렌지농장에 초대합니다.", message, to=[email]).send()
                 redirect(REDIRECT_PAGE)
+                return Response({'message': "회원가입 인증 메일이 전송되었습니다"})
             except SMTPException:
                 return Response({'error': "Email 발송에 문제가 있습니다. 다시 시도해주세요."},
                                 status=status.HTTP_503_SERVICE_UNAVAILABLE)


### PR DESCRIPTION
[Jira ON-43](https://orangenongjang.atlassian.net/browse/ON-43)

## Major Changes
- 회원가입 시 가입한 이메일로 회원인증링크가 전송되지만 # GET /api/v1/user/{uidb64}/activate/{token}/가 동작하지 않아 is_active가 False에서 True로 변하지 않는 에러를 수정함.

- prod 및 dev 환경 모두에서 링크가 메일을 통해 전송되며, 링크 클릭 시 is_active가 True로 바뀜을 확인했습니다.

- 링크 클릭 후 회원 인증이 완료되면 `https://orangenongjang.com/main/`로 redirect됩니다.