### PR TITLE
ON-47 [back/front] 타임라인에서 place 이름을 보여주도록 수정

### DIFF
--- a/nongjang/necessity/serializers.py
+++ b/nongjang/necessity/serializers.py
@@ -21,6 +21,7 @@ class NecessitySerializer(serializers.ModelSerializer):
 class NecessityOfPlaceWriteSerializer(serializers.ModelSerializer):
     id = serializers.IntegerField(source='necessity.id', read_only=True)
     place_id = serializers.IntegerField(source='place.id', read_only=True)
+    place_name = serializers.CharField(source='place.name', read_only=True)
     name = serializers.CharField(source='necessity.name', read_only=True)
     option = serializers.CharField(source='necessity.option', read_only=True)
 
@@ -29,6 +30,7 @@ class NecessityOfPlaceWriteSerializer(serializers.ModelSerializer):
         fields = (
             'id',
             'place_id',
+            'place_name',
             'name',
             'option',
             'description',

--- a/orange/src/api/necessity.ts
+++ b/orange/src/api/necessity.ts
@@ -3,6 +3,7 @@ import { User } from './user';
 export interface Necessity {
   id: number;
   place_id: number;
+  place_name: string;
   name: string;
   option: string;
   description: string;

--- a/orange/src/components/LogList/LogList.tsx
+++ b/orange/src/components/LogList/LogList.tsx
@@ -23,20 +23,21 @@ interface Props {
 function LogList(props: Props) {
   const { username } = props.logs.user;
   const necessityname = props.logs.necessity?.name;
+  const necessityplace = props.logs.necessity?.place_name;
   const createdAt = (new Date(props.logs.created_at)).toLocaleString();
 
   const activityCategory = () => {
     switch (props.logs.action) {
       case 'CREATE':
-        return '이/가 생필품 목록에 추가되었습니다.';
+        return `${necessityplace}에 ${necessityname} 추가`;
       case 'UPDATE':
-        return '이/가 수정되었습니다.';
+        return `${necessityplace}에서 ${necessityname} 정보 수정`;
       case 'DELETE':
-        return '이/가 생필품 목록에서 삭제되었습니다.';
+        return `${necessityplace}에서 ${necessityname} 삭제`;
       case 'COUNT':
-        return '의 수량이 변경되었습니다.';
+        return `${necessityplace}에서 ${necessityname}의 수량 변경`;
       default:
-        return '이/가 수정되었습니다.';
+        return `${necessityplace}에서 ${necessityname} 정보 수정`;
     }
   };
 
@@ -69,15 +70,13 @@ function LogList(props: Props) {
           </TimelineSeparator>
           <TimelineContent>
             <Paper elevation={3} className="log-message">
-              <Typography variant="h6" component="h1">
-                <b>{necessityname}</b>
+              <Typography variant="h5" component="h1">
                 {activityCategory()}
                 {' '}
               </Typography>
               <Typography>
-                (
+                by &nbsp;
                 {username}
-                )
               </Typography>
             </Paper>
             <Typography />


### PR DESCRIPTION
## Major Changes
#### 0. Summary
- place를 새로 생성할 수 있게 되면서 NecessityLog가 기록되는 **타임라인**에도 place 이름을 명시하라 필요가 생김.

<br>

#### 1. [back] NecessityOfPlaceWriteSerializer에 place_name 추가

<br>

#### 2. [front] LogList의 타임라인 문구 수정
- CREATE / UPDATE / DELETE / COUNT 각 행위에 따라 한국어 조사('을/를', '이/가' 등)가 필요하던 기존의 방식에서 조사가 필요하지 않도록 축약함.
- 행위자의 이름을 괄호에 넣는 방식 대신 'by 고영현'으로 수정.
- Log 문장의 크기를 한 단계 키움.