### PR TITLE
ON-52 [back/front] 로그인 시 미인증 회원에게 인증이 필요하다고 알리는 기능 수정

### DIFF
--- a/nongjang/user/views.py
+++ b/nongjang/user/views.py
@@ -1,6 +1,5 @@
 from django.conf import settings
 from django.contrib.auth import authenticate, login, logout
-from django.contrib.auth.hashers import check_password
 from django.contrib.auth.models import User
 from django.contrib.sites.shortcuts import get_current_site
 from django.core import mail
@@ -62,9 +61,8 @@ class UserViewSet(viewsets.GenericViewSet):
             if not user.is_active:
                 return Response({'error': "회원가입 인증이 완료되지 않았습니다."}, status=status.HTTP_401_UNAUTHORIZED)
             return Response(status=status.HTTP_403_FORBIDDEN)
-
+        login(request, user)
         return Response(self.get_serializer(user).data)
-
 
     @action(detail=False, methods=['GET'])
     def logout(self, request):

--- a/orange/src/containers/IntroPage/IntroPage.tsx
+++ b/orange/src/containers/IntroPage/IntroPage.tsx
@@ -27,7 +27,7 @@ function IntroPage() {
     if (loginStatus === userStatus.SUCCESS) {
       window.location.reload();
     } if (loginStatus === userStatus.FAILURE_INACTIVE) {
-      alert('회원 인증을 완료해주세요!');
+      alert('메일을 확인하여 회원 인증을 완료해주세요!');
       window.location.reload();
     } if (loginStatus === userStatus.FAILURE_INFO) {
       alert('잘못된 이름 또는 비밀번호입니다.');


### PR DESCRIPTION
# Major Changes
## 1. [back]
#### * 회원 가입 직후 인증을 받지 않고 로그인을 시도한 유저에게 401 error를 보내도록 일부 Logic 추가 및 Logic 순서 변경
> check_password 함수를 사용하여 username, password를 잘 입력한 미인증 회원에게는 HTTP_401_UNAUTHORIZED 에러 반환.

<br>

## 2. [front]
#### * "회원 인증을 완료해주세요!"  ->  "메일을 확인하여 회원 인증을 완료해주세요!"로 message 수정
<img width="1287" alt="image" src="https://user-images.githubusercontent.com/46114393/102363996-588d6480-3ff9-11eb-85c6-443426c27fd5.png">


<br>
<br>

## Minor Changes
- 각종 주석 제거
- 회원가입 인증 링크 클릭 시 response를 렌더링하는 front 페이지가 없는 상태이므로 굳이 user response를 반환하지 않고 바로 로그인 페이지로 redirect하도록 수정. (기존에는 serializer 이전의 redirect 기능이 작동하지 않던 상태)