### PR TITLE
ON-53 [back] House 초대 이메일 인증 API

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 pipeline {
   agent {
     node {
-      label 'master'
+      label 'orangenongjang'
     }
 
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 pipeline {
   agent {
     node {
-      label 'orangenongjang'
+      label 'master'
     }
 
   }

--- a/nongjang/house/text.py
+++ b/nongjang/house/text.py
@@ -1,0 +1,14 @@
+import os
+
+
+ENV_MODE = os.getenv('MODE', 'dev')
+
+
+def house_invite_message(domain, house_uidb64, user_uidb64, token, user, house, invited_user):
+    link = f"http://{domain}/api/v1/house/{house_uidb64}/user/{user_uidb64}/activate/{token}/"
+
+    return f"To. {invited_user}\n\n" \
+           f"{user.username}님이 {house.name} 초대장을 전송했습니다!\n" \
+           f"아래 링크를 클릭하면 {house.name}에 초대됩니다.\n\n" \
+           f"링크 : {link}\n\n" \
+           f"From. 오렌지농장(orangenongjang)"

--- a/nongjang/house/text.py
+++ b/nongjang/house/text.py
@@ -1,14 +1,8 @@
-import os
-
-
-ENV_MODE = os.getenv('MODE', 'dev')
-
-
 def house_invite_message(domain, house_uidb64, user_uidb64, token, user, house, invited_user):
     link = f"http://{domain}/api/v1/house/{house_uidb64}/user/{user_uidb64}/activate/{token}/"
 
-    return f"To. {invited_user}\n\n" \
-           f"{user.username}님이 {house.name} 초대장을 전송했습니다!\n" \
-           f"아래 링크를 클릭하면 {house.name}에 초대됩니다.\n\n" \
+    return f"To. [{invited_user}]\n\n" \
+           f" [{user.username}]님이 [{house.name}] 초대장을 전송했습니다!\n" \
+           f"아래 링크를 클릭하면 [{house.name}]에 초대됩니다.\n\n" \
            f"링크 : {link}\n\n" \
            f"From. 오렌지농장(orangenongjang)"

--- a/nongjang/house/urls.py
+++ b/nongjang/house/urls.py
@@ -1,7 +1,7 @@
 from django.urls import include, path
 from rest_framework.routers import SimpleRouter
 from house.views import (HouseViewSet, PlaceViewSet, PlaceNecessityView, PlaceNecessityCountView,
-                         HousePlaceView, HouseUserLeaderView)
+                         HousePlaceView, HouseUserLeaderView, HouseUserActivateView)
 
 app_name = 'house'
 
@@ -15,4 +15,5 @@ urlpatterns = [
     path('place/<int:place_id>/necessity/<int:necessity_id>/count/', PlaceNecessityCountView.as_view()),
     path('house/<int:house_id>/place/<int:place_id>/', HousePlaceView.as_view()),
     path('house/<int:house_id>/user/<int:user_id>/leader/', HouseUserLeaderView.as_view()),
+    path('house/<str:house_uidb64>/user/<str:user_uidb64>/activate/<str:token>/', HouseUserActivateView.as_view({'get': 'activate'})),
 ]

--- a/nongjang/house/views.py
+++ b/nongjang/house/views.py
@@ -135,7 +135,7 @@ class HouseViewSet(viewsets.GenericViewSet):
                 EmailMessage(subject, message, to=[email], connection=connection).send()
             except SMTPException:
                 return Response({'error': "Email 발송에 문제가 있습니다."}, status=status.HTTP_503_SERVICE_UNAVAILABLE)
-            return Response({'message': "입력하신 이메일로 초대장이 전송되었습니다."})
+        return Response({'message': "입력하신 이메일로 초대장이 전송되었습니다."})
 
     @action(detail=True, methods=['GET', 'DELETE'])
     def user(self, request, pk=None):

--- a/nongjang/house/views.py
+++ b/nongjang/house/views.py
@@ -1,7 +1,12 @@
+from django.conf import settings
 from django.contrib.auth.models import User
+from django.contrib.sites.shortcuts import get_current_site
 from django.core import mail
 from django.core.mail import EmailMessage
 from django.db import IntegrityError, transaction
+from django.shortcuts import redirect
+from django.utils.encoding import force_bytes, force_text
+from django.utils.http import urlsafe_base64_decode, urlsafe_base64_encode
 from rest_framework import status, viewsets
 from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticated
@@ -13,7 +18,8 @@ from house.models import House, Place, UserHouse
 from house.serializers import HouseSerializer, PlaceSerializer, SimpleHouseSerializer, UserOfHouseSerializer
 from necessity.models import Necessity, NecessityPlace, NecessityLog
 from necessity.serializers import NecessitySerializer, NecessityLogSerializer, NecessityOfPlaceWriteSerializer
-
+from house.text import house_invite_message
+from user.token import user_activation_token
 
 class HouseViewSet(viewsets.GenericViewSet):
     queryset = House.objects.filter(is_hidden=False)
@@ -107,37 +113,36 @@ class HouseViewSet(viewsets.GenericViewSet):
         email = request.data.get('email')
         if not email:
             return Response({'error': "Email 주소를 입력해주세요."}, status=status.HTTP_400_BAD_REQUEST)
-        if not User.objects.filter(email=email, is_active=True).exists():
+
+        invited_user = User.objects.filter(email=email).last()
+        if not invited_user:
             return Response({'error': "등록되지 않은 Email입니다."}, status=status.HTTP_404_NOT_FOUND)
-        # FIXME: Serializer를 통해 올바른 email 형식인지 검증할 필요가 있음. 현재 user에 대한 validation이 없어 리팩토링해야 함.(ON-35)
+        elif not invited_user.is_active:
+            return Response({'error': "초대장을 받으려면 회원 인증을 완료해야 합니다."}, status=status.HTTP_401_UNAUTHORIZED)
+        else:
+            if UserHouse.objects.filter(house=house, user=invited_user).exists():
+                return Response({'error': "이미 House에 등록된 멤버입니다."}, status=status.HTTP_409_CONFLICT)
 
-        subject = "오렌지농장 House에 초대합니다."
-        message = f"{user.username}님께서 {house.name} 초대장을 보내셨습니다. 아래 링크를 클릭하여 초대를 수락하세요."
-        with mail.get_connection() as connection:
-            try:
-                EmailMessage(subject, message, to=[email], connection=connection).send()
-            except SMTPException:
-                return Response({'error': "Email 발송에 문제가 있습니다."}, status=status.HTTP_503_SERVICE_UNAVAILABLE)
-        return Response({'message': "입력하신 이메일로 초대장이 전송되었습니다."})
+            with mail.get_connection() as connection:
+                subject = "오렌지농장 House에 초대합니다."
+                domain = get_current_site(request).domain
+                user_uidb64 = urlsafe_base64_encode(force_bytes(invited_user.id))
+                house_uidb64 = urlsafe_base64_encode(force_bytes(house.id))
+                token = user_activation_token.make_token(invited_user)
+                message = house_invite_message(domain, house_uidb64, user_uidb64, token, user, house, invited_user)
+                try:
+                    EmailMessage(subject, message, to=[email], connection=connection).send()
+                except SMTPException:
+                    return Response({'error': "Email 발송에 문제가 있습니다."}, status=status.HTTP_503_SERVICE_UNAVAILABLE)
+            return Response({'message': "입력하신 이메일로 초대장이 전송되었습니다."})
 
-    @action(detail=True, methods=['POST', 'GET', 'DELETE'])
+    @action(detail=True, methods=['GET', 'DELETE'])
     def user(self, request, pk=None):
         house = self.get_object()
-        if self.request.method == 'POST':
-            return self._join_house(house)
-        elif self.request.method == 'GET':
+        if self.request.method == 'GET':
             return self._get_members(house)
         else:
             return self._leave_house(house)
-
-    def _join_house(self, house):
-        user = self.request.user
-        user_house = user.user_houses.filter(house=house).last()
-        if user_house:
-            return Response({'error': "이미 소속되어 있는 집입니다."}, status=status.HTTP_409_CONFLICT)
-
-        UserHouse.objects.create(user=user, house=house)
-        return Response(self.get_serializer(house).data, status=status.HTTP_201_CREATED)
 
     def _get_members(self, house):
         members = house.user_houses.all()
@@ -382,3 +387,30 @@ class HouseUserLeaderView(APIView):
             to_user_house.is_leader = True
             to_user_house.save()
         return Response(UserOfHouseSerializer(user_houses, many=True).data)
+
+
+class HouseUserActivateView(viewsets.GenericViewSet):
+    queryset = User.objects.all()
+
+    # GET /api/v1/house/{house_uidb64}/user/{user_uidb64}/activate/{token}/
+    @action(detail=False, methods=['GET'])
+    def activate(self, request, *args, **kwargs):
+        house_uidb64 = kwargs['house_uidb64']
+        user_uidb64 = kwargs['user_uidb64']
+        token = kwargs['token']
+        house = House.objects.get(id=force_text(urlsafe_base64_decode(house_uidb64)))
+        user = User.objects.get(id=force_text(urlsafe_base64_decode(user_uidb64)))
+
+        if not house or not user:
+            return Response({'error': "잘못된 접근입니다."}, status=status.HTTP_401_UNAUTHORIZED)
+        try:
+            if user_activation_token.check_token(user, token):
+                try:
+                    UserHouse.objects.create(user=user, house=house)
+                except IntegrityError:
+                    return Response({'error': "이미 House에 등록된 멤버입니다."}, status=status.HTTP_409_CONFLICT)
+            else:
+                return Response({'error': "유효하지 않은 키입니다."}, status=status.HTTP_400_BAD_REQUEST)
+        except KeyError:
+            return Response({'error': "인증 키에 문제가 생겼습니다. 다시 시도해주세요."}, status=status.HTTP_400_BAD_REQUEST)
+        return redirect(settings.REDIRECT_PAGE)


### PR DESCRIPTION
# Major Changes 
[Jira ON-53](https://orangenongjang.atlassian.net/browse/ON-53)
## 1. House 초대 시 Email로 수락하는 API 구축
- 회원가입 직후 미인증된 회원을 House에 초대할 때 401 error로 대응
- 이미 활동중인 멤버를 House에 초대할 때 409 error로 대응 (`def invitation`)
 > activation link를 조작하는 등 부정한 방법으로 이미 활동중인 멤버가 다시금 userHouse에 초대될 때 발생하는 integrityError를 막기 위해 `def activate`에서도 409 error로 대응

<br>

## 2. 이메일 메시지 구체화
- <img width="705" alt="image" src="https://user-images.githubusercontent.com/46114393/102386982-2b4db000-4013-11eb-9266-4f41ff8925dc.png">

