### PR TITLE
Revert "deploying django static files"

### DIFF
--- a/Dockerrun.aws.json
+++ b/Dockerrun.aws.json
@@ -1,13 +1,6 @@
 {
   "AWSEBDockerrunVersion": 2,
-  "volumes": [
-     {
-       "name": "django_static",
-       "host": {
-         "sourcePath": "/var/app/current/nongjang/static"
-       }
-     }
-   ],
+  "volumes": [],
   "containerDefinitions": [
     {
       "name": "code",
@@ -21,10 +14,6 @@
       "essential": true,
       "memory": 256,
       "mountPoints": [
-        {
-          "sourceVolume": "django_static",
-          "containerPath": "/app/api/nongjang/static"
-        },
         {
           "sourceVolume": "awseb-logs-code",
           "containerPath": "/var/log/code"
@@ -50,11 +39,6 @@
         "code"
       ],
       "mountPoints": [
-        {
-          "sourceVolume": "django_static",
-          "containerPath": "/var/www/django_static",
-          "readOnly": true
-        },
         {
           "sourceVolume": "awseb-logs-nginx",
           "containerPath": "/var/log/nginx"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,8 +8,6 @@ services:
     build:
       context: ./nongjang/
       dockerfile: Dockerfile
-    volumes:
-      - django_static:/app/api/nongjang/static
 
   nginx:
     container_name: nginx
@@ -19,10 +17,5 @@ services:
       dockerfile: Dockerfile
     ports:
       - "80:80"
-    volumes:
-      - django_static:/var/www/django_static
     depends_on:
       - nongjang
-
-volumes:
-  django_static:

--- a/nginx-app.conf
+++ b/nginx-app.conf
@@ -21,10 +21,6 @@ server {
         include uwsgi_params;
     }
 
-    location /static {
-        alias /var/www/django_static/;
-    }
-
     proxy_set_header Host $http_host;
     proxy_redirect off;
     proxy_set_header X-Real-IP $remote_addr;

--- a/nongjang/Dockerfile
+++ b/nongjang/Dockerfile
@@ -7,5 +7,4 @@ RUN apt-get update \
     && pip install -r requirements.txt \
     && pip install -U pip uwsgi
 COPY . ./
-RUN python manage.py collectstatic
 CMD ["uwsgi", "--ini", "uwsgi.ini"]

--- a/nongjang/nongjang/settings.py
+++ b/nongjang/nongjang/settings.py
@@ -176,7 +176,6 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/3.0/howto/static-files/
 
 STATIC_URL = '/static/'
-STATIC_ROOT = os.path.join(BASE_DIR, 'static')
 
 if USE_DEBUG_TOOLBAR:
     INSTALLED_APPS += (


### PR DESCRIPTION
Reverts gongmyeong-study/orangenongjang#88

Docker build 단계에서 collectstatic 하려면 Secrets Manager 때문에 AWS credentials가 필요한데, 이를 건네주는 방식에 대한 고민이 필요함.