### PR TITLE
ON-70 [front] Place 이름 수정 button 꾸미기 및 image 교체

### DIFF
--- a/orange/src/components/PlaceBox/PlaceBox.css
+++ b/orange/src/components/PlaceBox/PlaceBox.css
@@ -51,6 +51,6 @@
 }
 
 .place-update-input {
-    width: 16vw;
+    width: 18vw;
     height: 4vh;
 }

--- a/orange/src/components/PlaceBox/PlaceBox.css
+++ b/orange/src/components/PlaceBox/PlaceBox.css
@@ -32,3 +32,25 @@
     bottom: 0;
     background: rgba(0, 0, 0, 0.5);
 }
+
+.place-update-box {
+    display: flex;
+}
+
+.place-update-box div:last-child {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    margin-top: 10px;
+}
+
+.place-update-box button {
+    width: 4vw;
+    height: 3vh;
+    border-radius: 5px;
+}
+
+.place-update-input {
+    width: 16vw;
+    height: 4vh;
+}

--- a/orange/src/components/PlaceBox/PlaceBox.tsx
+++ b/orange/src/components/PlaceBox/PlaceBox.tsx
@@ -82,15 +82,20 @@ function PlaceBox(props: Props) {
       </Modal>
       <h1>
         <EdiText
+          viewContainerClassName="place-update-box"
+          editButtonContent={<i className="fas fa-pencil-alt" />}
+          saveButtonContent={<i className="fas fa-check" />}
+          cancelButtonContent={<i className="fas fa-times" />}
+          hideIcons
           type="text"
-          editButtonClassName="far fa-pencil-alt"
           showButtonsOnHover
           submitOnUnfocus
           submitOnEnter
           cancelOnEscape
           inputProps={{
-            className: 'text',
+            className: 'place-update-input',
             placeholder: 'Place 이름을 입력하세요.',
+            style: { fontSize: 18 },
           }}
           validationMessage="한 글자 이상 입력하세요."
           validation={(val) => val.length > 0}


### PR DESCRIPTION
> [Jira ON-70](https://orangenongjang.atlassian.net/browse/ON-70)

# Major Changes

### 1. button image 변경
- chrome에서 pencil 모양의 icon이 보이지 않던 현상을 수정

<img width="470" alt="image" src="https://user-images.githubusercontent.com/46114393/105708095-46d3a100-5f57-11eb-8750-ceacf6f33a81.png">

<br>

### 2. button에 css 적용
- input box의 크기가 Place name에 비해 작아 수정 시에 부자연스럽게 보이던 현상을 수정
- input text 및 placeholder 길이에 맞추어 input box width 조절


<img width="462" alt="image" src="https://user-images.githubusercontent.com/46114393/105708077-3f13fc80-5f57-11eb-985c-c6e703a62fb6.png">


<img width="489" alt="image" src="https://user-images.githubusercontent.com/46114393/105708161-5eab2500-5f57-11eb-8427-b45659521efe.png">


<br>

