### PR TITLE
ON-85 [back] 회원인증 및 House 초대장 메일 링크가 http인 부분 수정

### DIFF
--- a/nongjang/house/text.py
+++ b/nongjang/house/text.py
@@ -1,8 +1,8 @@
 def house_invite_message(domain, house_uidb64, user_uidb64, token, user, house, invited_user):
     link = f"{domain}/{house_uidb64}/user/{user_uidb64}/activate/{token}/"
 
-    return f"To. [ {invited_user} ]\n\n" \
-           f" [ {user.username} ]님이 [ {house.name} ] 초대장을 전송했습니다!\n" \
+    return f"To. [ {invited_user} ]\n\n\n\n" \
+           f" [ {user.username} ]님이 [ {house.name} ] 초대장을 전송했습니다!\n\n" \
            f"아래 링크를 클릭하면 [ {house.name} ]에 초대됩니다.\n\n" \
-           f"링크 : {link}\n\n" \
+           f"링크 : {link}\n\n\n\n" \
            f"From. 오렌지농장(orangenongjang)"

--- a/nongjang/house/text.py
+++ b/nongjang/house/text.py
@@ -1,8 +1,8 @@
 def house_invite_message(domain, house_uidb64, user_uidb64, token, user, house, invited_user):
-    link = f"http://{domain}/api/v1/house/{house_uidb64}/user/{user_uidb64}/activate/{token}/"
+    link = f"{domain}/{house_uidb64}/user/{user_uidb64}/activate/{token}/"
 
-    return f"To. [{invited_user}]\n\n" \
-           f" [{user.username}]님이 [{house.name}] 초대장을 전송했습니다!\n" \
-           f"아래 링크를 클릭하면 [{house.name}]에 초대됩니다.\n\n" \
+    return f"To. [ {invited_user} ]\n\n" \
+           f" [ {user.username} ]님이 [ {house.name} ] 초대장을 전송했습니다!\n" \
+           f"아래 링크를 클릭하면 [ {house.name} ]에 초대됩니다.\n\n" \
            f"링크 : {link}\n\n" \
            f"From. 오렌지농장(orangenongjang)"

--- a/nongjang/house/text.py
+++ b/nongjang/house/text.py
@@ -1,5 +1,5 @@
 def house_invite_message(domain, house_uidb64, user_uidb64, token, user, house, invited_user):
-    link = f"{domain}/{house_uidb64}/user/{user_uidb64}/activate/{token}/"
+    link = f"{domain}api/v1/house/{house_uidb64}/user/{user_uidb64}/activate/{token}/"
 
     return f"To. [ {invited_user} ]\n\n\n\n" \
            f" [ {user.username} ]님이 [ {house.name} ] 초대장을 전송했습니다!\n\n" \

--- a/nongjang/house/views.py
+++ b/nongjang/house/views.py
@@ -110,6 +110,9 @@ class HouseViewSet(viewsets.GenericViewSet):
         user = request.user
         house = self.get_object()
 
+        print(request.build_absolute_uri('/'))
+        print(request.build_absolute_uri(''))
+
         user_house = user.user_houses.filter(house=house).last()
         if not user_house.is_leader:
             return Response({'error': "leader만 초대장을 전송할 수 있습니다."}, status=status.HTTP_403_FORBIDDEN)
@@ -129,7 +132,7 @@ class HouseViewSet(viewsets.GenericViewSet):
 
         with mail.get_connection() as connection:
             subject = "오렌지농장 House에 초대합니다."
-            domain = request.build_absolute_uri('/api/v1/house')
+            domain = request.build_absolute_uri('/')
             user_uidb64 = urlsafe_base64_encode(force_bytes(invited_user.id))
             house_uidb64 = urlsafe_base64_encode(force_bytes(house.id))
             token = user_activation_token.make_token(invited_user)

--- a/nongjang/house/views.py
+++ b/nongjang/house/views.py
@@ -129,7 +129,7 @@ class HouseViewSet(viewsets.GenericViewSet):
 
         with mail.get_connection() as connection:
             subject = "오렌지농장 House에 초대합니다."
-            domain = get_current_site(request).domain
+            domain = request.build_absolute_uri('/api/v1/house')
             user_uidb64 = urlsafe_base64_encode(force_bytes(invited_user.id))
             house_uidb64 = urlsafe_base64_encode(force_bytes(house.id))
             token = user_activation_token.make_token(invited_user)

--- a/nongjang/user/text.py
+++ b/nongjang/user/text.py
@@ -1,13 +1,9 @@
-import os
-
-
-ENV_MODE = os.getenv('MODE', 'dev')
-
-
 def user_invite_message(domain, uidb64, token, user):
-    link = f"http://{domain}/api/v1/user/{uidb64}/activate/{token}/"
+    link = f"{domain}/{uidb64}/activate/{token}/"
 
-    return f"{user} 님께\n\n\n\n" \
+    return f"To. [ {user} ]\n\n\n\n" \
            f"아래 링크를 클릭하면 회원 인증이 완료됩니다.\n\n" \
            f"링크 : {link}\n\n" \
-           f"오렌지농장에 오신 것을 환영합니다 :)"
+           f"오렌지농장에 오신 것을 환영합니다 :)\n\n" \
+           f"From. 오렌지농장(orangenongjang)"
+

--- a/nongjang/user/text.py
+++ b/nongjang/user/text.py
@@ -4,6 +4,5 @@ def user_invite_message(domain, uidb64, token, user):
     return f"To. [ {user} ]\n\n\n\n" \
            f"아래 링크를 클릭하면 회원 인증이 완료됩니다.\n\n" \
            f"링크 : {link}\n\n" \
-           f"오렌지농장에 오신 것을 환영합니다 :)\n\n" \
+           f"오렌지농장에 오신 것을 환영합니다 :)\n\n\n\n" \
            f"From. 오렌지농장(orangenongjang)"
-

--- a/nongjang/user/text.py
+++ b/nongjang/user/text.py
@@ -1,5 +1,5 @@
 def user_invite_message(domain, uidb64, token, user):
-    link = f"{domain}/{uidb64}/activate/{token}/"
+    link = f"{domain}api/v1/user/{uidb64}/activate/{token}/"
 
     return f"To. [ {user} ]\n\n\n\n" \
            f"아래 링크를 클릭하면 회원 인증이 완료됩니다.\n\n" \

--- a/nongjang/user/views.py
+++ b/nongjang/user/views.py
@@ -36,7 +36,7 @@ class UserViewSet(viewsets.GenericViewSet):
             return Response({'error': "같은 정보의 사용자가 이미 존재합니다."}, status=status.HTTP_400_BAD_REQUEST)
 
         with mail.get_connection():
-            domain = request.build_absolute_uri('/api/v1/user')
+            domain = request.build_absolute_uri('/')
             uidb64 = urlsafe_base64_encode(force_bytes(user.pk))
             token = user_activation_token.make_token(user)
             message = user_invite_message(domain, uidb64, token, user)

--- a/nongjang/user/views.py
+++ b/nongjang/user/views.py
@@ -36,7 +36,7 @@ class UserViewSet(viewsets.GenericViewSet):
             return Response({'error': "같은 정보의 사용자가 이미 존재합니다."}, status=status.HTTP_400_BAD_REQUEST)
 
         with mail.get_connection():
-            domain = get_current_site(request).domain
+            domain = request.build_absolute_uri('/api/v1/user')
             uidb64 = urlsafe_base64_encode(force_bytes(user.pk))
             token = user_activation_token.make_token(user)
             message = user_invite_message(domain, uidb64, token, user)


### PR DESCRIPTION
> [Jira ON-85](https://orangenongjang.atlassian.net/browse/ON-85)

# Major Changes
### 1. 회원인증 및 House 초대장 링크 수정
- `build_absolute_uri() will always generate an absolute URI with the same scheme the current request has.` 참고하여 user 및 house text.py의 link에 **http** 또는 **https** 명시를 하지 않도록 수정함

<br>

### 2. 회원인증 문구 수정
- House 초대장의 어투, 형식을 맞추어 통일성 제고

<br>
<br>

참고 : [django docs](https://docs.djangoproject.com/en/dev/ref/request-response/#django.http.HttpRequest.build_absolute_uri)
<img width="905" alt="image" src="https://user-images.githubusercontent.com/46114393/106376883-7281db80-63dc-11eb-8402-3a4e3acb6465.png">
