### PR TITLE
ON-71 [front] 클릭할 수 있는 컴포넌트 커서 변경

### DIFF
--- a/orange/src/components/Header/Header.css
+++ b/orange/src/components/Header/Header.css
@@ -16,6 +16,7 @@
   padding: 0;
   margin: auto;
   font: 500 1em 'Noto Sans KR', sans-serif;
+  cursor: pointer;
 }
 
 .main-header-li-hello {

--- a/orange/src/containers/HousePage/HousePage.scss
+++ b/orange/src/containers/HousePage/HousePage.scss
@@ -56,6 +56,7 @@ button {
       height: 2.2rem;
       width: 4rem;
       color: $orange;
+      cursor: pointer;
 
       &:hover {
         background-color: $orange;
@@ -74,6 +75,7 @@ button {
     color: white;
     max-width: 600px;
     max-height: 300px;
+    cursor: pointer;
 
     &:hover {
       background-color: $light-orange-hover;
@@ -127,6 +129,7 @@ button {
         border-radius: 100px;
         color: $orange;
         text-shadow: 1px 1px 1px rgba(0, 0, 0, 0.1);
+        cursor: pointer;
 
         &:hover {
           background-color: $orange;

--- a/orange/src/containers/IntroPage/IntroPage.scss
+++ b/orange/src/containers/IntroPage/IntroPage.scss
@@ -144,6 +144,7 @@
                     padding: 32px 72px;
                     display: flex;
                     align-items: center;
+                    cursor: pointer;
                 }
     
                 button:nth-child(2) {

--- a/orange/src/containers/MainPage/MainPage.css
+++ b/orange/src/containers/MainPage/MainPage.css
@@ -7,6 +7,7 @@
 .main-tabs {
     margin: 3% 20%;
     display: flex;
+    cursor: pointer;
 }
 
 .main-tab {


### PR DESCRIPTION
각종 컴포넌트( 로그인&회원가입 클릭 / house 입장&관리&초대 클릭 /  main 탭 4개 ) css에 `cursor: pointer`를 추가하여 사용자들로 하여금 커서 위치가 클릭가능한 곳임을 알게 됩니다.