### PR TITLE
ON-90 [release] 가입 및 House 초대 메일 이쁘게 꾸미기

### DIFF
--- a/nongjang/house/text.py
+++ b/nongjang/house/text.py
@@ -1,8 +1,14 @@
+def house_invite_subject(self):
+    return "오렌지농장 House에 초대합니다."
+
+
 def house_invite_message(domain, house_uidb64, user_uidb64, token, user, house, invited_user):
     link = f"{domain}api/v1/house/{house_uidb64}/user/{user_uidb64}/activate/{token}/"
 
-    return f"To. [ {invited_user} ]\n\n\n\n" \
-           f" [ {user.username} ]님이 [ {house.name} ] 초대장을 전송했습니다!\n\n" \
-           f"아래 링크를 클릭하면 [ {house.name} ]에 초대됩니다.\n\n" \
-           f"링크 : {link}\n\n\n\n" \
-           f"From. 오렌지농장(orangenongjang)"
+    return f"<h2> To. {invited_user}</h2> <br>" \
+           f"<span style='font-size: 14px'> <strong>{user.username}</strong> 님이 <strong>{house.name}</strong> 초대장을 전송했습니다! <br>" \
+           f"아래 <a href='{link}'>링크</a>로 접속하면 <strong>{house.name}</strong> 에 초대됩니다. <br><br>" \
+           f"링크 : {link} <br><br><br> </span>" \
+           f"<h2> From. 오렌지농장(orangenongjang)</h2>" \
+           f"<img src='https://orangenongjang-static.s3.ap-northeast-2.amazonaws.com/image/orangenongjang_logo_2.png' " \
+           f"alt='Orangenongjang_logo' width='550' height='500'>"

--- a/nongjang/user/text.py
+++ b/nongjang/user/text.py
@@ -1,8 +1,14 @@
+def user_invite_subject(self):
+    return "오렌지농장 가입인증 메일입니다."
+
+
 def user_invite_message(domain, uidb64, token, user):
     link = f"{domain}api/v1/user/{uidb64}/activate/{token}/"
 
-    return f"To. [ {user} ]\n\n\n\n" \
-           f"아래 링크를 클릭하면 회원 인증이 완료됩니다.\n\n" \
-           f"링크 : {link}\n\n" \
-           f"오렌지농장에 오신 것을 환영합니다 :)\n\n\n\n" \
-           f"From. 오렌지농장(orangenongjang)"
+    return f"<h2> To. {user}</h2> <br>" \
+           f"<span style='font-size: 14px'> 아래 <a href='{link}'>링크</a>로 접속하면 회원 인증이 완료됩니다. <br>" \
+           f"링크 : {link} <br><br> </span>" \
+           f"오렌지농장에 오신 것을 환영합니다 :)</span> <br><br><br>" \
+           f"<h2> From. 오렌지농장(orangenongjang)</h2>" \
+           f"<img src='https://orangenongjang-static.s3.ap-northeast-2.amazonaws.com/image/orangenongjang_logo_2.png'" \
+           f"alt='Orangenongjang_logo' width='550' height='500'>"


### PR DESCRIPTION
> Jira [ON-90](https://orangenongjang.atlassian.net/browse/ON-90)

# Major Changes
### 1. 회원가입 인증 및 House 초대 메일 수정
- html 태그를 사용하기 위해 기존의 `EmailMessage` 모듈 대신 `EmailMultiAlternatives`를 사용함.
- 메일 제목을 views.py에서 하드코딩하던 기존의 방식을 피하기 위해 text.py에서 처리함.

<br>

### 2. 메일에 Orangenongajgn 로고 포함
<img width="687" alt="image" src="https://user-images.githubusercontent.com/46114393/107798223-2f8e1380-6d9f-11eb-890c-48356bb82585.png">

<br>
