### PR TITLE
ON-101 [front] 중복된 생필품(이름 및 설명) 생성 및 수량이 0인 생필품 감소 버튼 클릭 시 에러 처리 방식 개선

### DIFF
--- a/orange/src/components/Necessity/NecessityCounterButton/NecessityCounterButton.tsx
+++ b/orange/src/components/Necessity/NecessityCounterButton/NecessityCounterButton.tsx
@@ -28,7 +28,10 @@ function NecessityCounterButton(props: Props) {
   };
 
   return (
-    <Button onClick={props.countType === 'add' ? addCount : subtractCount}>
+    <Button
+      onClick={props.countType === 'add' ? addCount : subtractCount}
+      disabled={props.countType === 'subtract' && props.count === 0}
+    >
       <i className={`far ${props.countType === 'add' ? 'fa-plus-square' : 'fa-minus-square'} fa-2x`} />
     </Button>
   );

--- a/orange/src/store/actions/necessity/necessity.tsx
+++ b/orange/src/store/actions/necessity/necessity.tsx
@@ -68,7 +68,7 @@ const createNecessityPlaceFailure = (error: AxiosError) => {
   switch (error.response?.status) {
     case 409:
       actionType = necessityConstants.CREATE_NECESSITYPLACE_FAILURE_NAME;
-      alert('같은 이름의 Necessity가 존재합니다.');
+      alert('이름과 설명이 같은 Necessity가 존재합니다.');
       break;
     default:
       actionType = necessityConstants.CREATE_NECESSITYPLACE_FAILURE;


### PR DESCRIPTION
> Jira [ON-101](https://orangenongjang.atlassian.net/browse/ON-101)

# Major Changes
### 1. **이름**과 **설명**이 같은 생필품 생성 시 alert message 수정
- 기존의 `같은 이름의 Necessity가 존재합니다.` 에서 `이름과 설명이 같은 Necessity가 존재합니다.`로 메시지 변경
<img width="486" alt="image" src="https://user-images.githubusercontent.com/46114393/108324323-1952de00-720b-11eb-86d3-9d8858c3d4cc.png">

<br>

### 2. 생필품 수량이 0일 때 감소 버튼을 비활성화
<img width="317" alt="image" src="https://user-images.githubusercontent.com/46114393/108324560-68990e80-720b-11eb-9358-0d8841993305.png">


<br>