### PR TITLE
ON-32, 46, 88 [front] 생필품 관련 modal에서 price/count 입력값 설정

### DIFF
--- a/orange/src/components/Necessity/NecessityCounterButton/NecessityCounterButton.tsx
+++ b/orange/src/components/Necessity/NecessityCounterButton/NecessityCounterButton.tsx
@@ -30,7 +30,10 @@ function NecessityCounterButton(props: Props) {
   return (
     <Button
       onClick={props.countType === 'add' ? addCount : subtractCount}
-      disabled={props.countType === 'subtract' && props.count === 0}
+      disabled={
+        (props.countType === 'add' && props.count === 4294967295)
+        || (props.countType === 'subtract' && props.count === 0)
+      }
     >
       <i className={`far ${props.countType === 'add' ? 'fa-plus-square' : 'fa-minus-square'} fa-2x`} />
     </Button>

--- a/orange/src/components/Necessity/NecessityCreateOrUpdateForm/NecessityCreateOrUpdateForm.tsx
+++ b/orange/src/components/Necessity/NecessityCreateOrUpdateForm/NecessityCreateOrUpdateForm.tsx
@@ -130,14 +130,24 @@ function NecessityCreateOrUpdateForm(props: Props) {
                 <h4 style={{ marginRight: '3em' }}>가격</h4>
               </InputAdornment>
             ),
+            inputMode: 'numeric',
           }}
           name="price"
-          inputRef={register({ required: true })}
-          error={Boolean(errors.price)}
           type="number"
-          defaultValue={necessityToBeUpdated && necessityToBeUpdated.price}
+          inputRef={register({
+            min: {
+              value: 0,
+              message: 'Value should be at least 1',
+            },
+            max: {
+              value: 4294967295,
+              message: 'Value should be at most 2^32 - 1 (= 4294967295)',
+            },
+          })}
+          error={Boolean(errors.price)}
           className="text-input"
-          helperText={errors.count && '가격을 입력해주세요!'}
+          defaultValue={necessityToBeUpdated ? necessityToBeUpdated.price : 0}
+          helperText={errors.price && '올바른 양의 정수값을 입력해주세요!'}
         />
         <TextField
           InputProps={{
@@ -149,11 +159,21 @@ function NecessityCreateOrUpdateForm(props: Props) {
           }}
           name="count"
           type="number"
-          inputRef={register({ required: true })}
+          inputRef={register({
+            required: true,
+            min: {
+              value: 0,
+              message: 'Count should be at least 0',
+            },
+            max: {
+              value: 4294967295,
+              message: 'Count should be at most 2^32 - 1 (= 4294967295)',
+            },
+          })}
           error={Boolean(errors.count)}
           className="text-input"
-          defaultValue={necessityToBeUpdated && necessityToBeUpdated.count}
-          helperText={errors.count && '개수를 입력해주세요!'}
+          defaultValue={necessityToBeUpdated ? necessityToBeUpdated.count : 0}
+          helperText={errors.count && '올바른 양의 정수값을 입력해주세요!'}
         />
         <Button type="submit">{submitIcon}</Button>
       </form>

--- a/orange/src/components/Necessity/NecessityCreateOrUpdateForm/NecessityCreateOrUpdateForm.tsx
+++ b/orange/src/components/Necessity/NecessityCreateOrUpdateForm/NecessityCreateOrUpdateForm.tsx
@@ -137,10 +137,10 @@ function NecessityCreateOrUpdateForm(props: Props) {
           inputRef={register({
             min: {
               value: 0,
-              message: 'Value should be at least 1',
+              message: 'Value should be at least 0',
             },
             max: {
-              value: 4294967295,
+              value: 2 ** 32 - 1,
               message: 'Value should be at most 2^32 - 1 (= 4294967295)',
             },
           })}
@@ -166,7 +166,7 @@ function NecessityCreateOrUpdateForm(props: Props) {
               message: 'Count should be at least 0',
             },
             max: {
-              value: 4294967295,
+              value: 2 ** 32 - 1,
               message: 'Count should be at most 2^32 - 1 (= 4294967295)',
             },
           })}


### PR DESCRIPTION
> Jira [ON-32](https://orangenongjang.atlassian.net/browse/ON-32), [ON-46](https://orangenongjang.atlassian.net/browse/ON-46),  [ON-88](https://orangenongjang.atlassian.net/browse/ON-88)

# Major Changes
### 1. 생필품 관련 modal에서 price/count 하한/상한값 설정
- price와 count의 **하한값**은 0으로, **상한값**은 2^32 - 1인 4294967295로 설정함.
- Boundary 초과 시 API Call을 날려 Error Case를 확인하기보다 Front 단에서 price/count가 변경 불가하다는 **"올바른 양의 정수값을 입력해주세요!"** 메시지를 반환

<img width="464" alt="image" src="https://user-images.githubusercontent.com/46114393/108537045-7b513780-7320-11eb-856f-0ccacf0b3005.png">

<br>

### 2. 생필품 price default를 0으로 설정

<br>
