### PR TITLE
ON-80 Place 반복 생성하면 추가된 Place가 바로 렌더링되지 않는 문제

### DIFF
--- a/nongjang/house/views.py
+++ b/nongjang/house/views.py
@@ -184,7 +184,9 @@ class HouseViewSet(viewsets.GenericViewSet):
             if Place.objects.select_for_update().filter(house=house, name=name, is_hidden=False).exists():
                 return Response({'error': "같은 name의 공간을 이 집에가지고 있습니다."}, status=status.HTTP_409_CONFLICT)
             place = Place.objects.create(house=house, name=name)
-        return Response(self.get_serializer(place).data, status=status.HTTP_201_CREATED)
+
+        places = Place.objects.filter(house=house, is_hidden=False)
+        return Response(self.get_serializer(places, many=True).data, status=status.HTTP_201_CREATED)
 
     def _get_places(self, house):
         return Response(self.get_serializer(house.places.filter(is_hidden=False), many=True).data)

--- a/orange/.eslintrc.js
+++ b/orange/.eslintrc.js
@@ -1,38 +1,45 @@
 module.exports = {
-    extends: [
-      "airbnb-typescript",
-      "airbnb/hooks",
-      "plugin:@typescript-eslint/eslint-recommended",
-      "plugin:@typescript-eslint/recommended",
-      "plugin:@typescript-eslint/recommended-requiring-type-checking",
+  extends: [
+    "airbnb-typescript",
+    "airbnb/hooks",
+    "plugin:@typescript-eslint/eslint-recommended",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:@typescript-eslint/recommended-requiring-type-checking",
+  ],
+  parser: "@typescript-eslint/parser",
+  parserOptions: {
+    project: "./tsconfig.json",
+  },
+  plugins: ["@typescript-eslint", "prettier"],
+  settings: {
+    "import/parsers": {
+      "@typescript-eslint/parser": [".ts", ".tsx"],
+    },
+    "import/resolver": {
+      node: {
+        extensions: [".js", ".jsx", ".ts", ".tsx"],
+      },
+    },
+  },
+  rules: {
+    "react/jsx-filename-extension": [
+      2,
+      { extensions: [".js", ".jsx", ".ts", ".tsx"] },
     ],
-    parser: '@typescript-eslint/parser',
-    parserOptions: {
-      project: './tsconfig.json',
-    },
-    plugins: ['@typescript-eslint', 'prettier'],
-    settings: {
-      "import/parsers": {
-        '@typescript-eslint/parser': ['.ts', '.tsx'],
-      },
-      "import/resolver": {
-        "node": {
-          "extensions": [".js", ".jsx", ".ts", ".tsx"]
-        }
-      },
-    },
-    rules: {
-      'react/jsx-filename-extension': [2, { extensions: ['.js', '.jsx', '.ts', '.tsx'] }],
-      'react/destructuring-assignment': 0,
-      'prefer-destructuring': 1,
-      'react/prefer-stateless-function': 0,
-      'import/no-extraneous-dependencies': [2, { devDependencies: ['**/test.tsx', '**/test.ts'] }],
-      '@typescript-eslint/explicit-function-return-type': 0,
-      '@typescript-eslint/no-explicit-any': 0,
-      'jsx-a11y/label-has-associated-control': 0,
-      'jsx-a11y/click-events-have-key-events': 0,
-      'jsx-a11y/no-static-element-interactions': 0,
-      'no-alert': 0,
-      'no-console': 0,
-    }
+    "react/destructuring-assignment": 0,
+    "prefer-destructuring": 1,
+    "react/prefer-stateless-function": 0,
+    "import/no-extraneous-dependencies": [
+      2,
+      { devDependencies: ["**/test.tsx", "**/test.ts"] },
+    ],
+    "@typescript-eslint/explicit-function-return-type": 0,
+    "@typescript-eslint/no-explicit-any": 0,
+    "jsx-a11y/label-has-associated-control": 0,
+    "jsx-a11y/click-events-have-key-events": 0,
+    "jsx-a11y/no-static-element-interactions": 0,
+    "no-alert": 0,
+    "no-console": 0,
+    "max-len": ["error", { code: 130 }],
+  },
 };

--- a/orange/src/containers/NecessityPage/NecessityPage.tsx
+++ b/orange/src/containers/NecessityPage/NecessityPage.tsx
@@ -21,23 +21,23 @@ interface Props {
 
 function NecessityPage(props: Props) {
   const [isModalOpen, setModalOpen] = useState(false);
-  const { createStatus, places } = useSelector((state: OrangeGlobalState) => state.necessity);
+  const { createPlaceStatus, places } = useSelector(
+    (state: OrangeGlobalState) => state.necessity,
+  );
   const { house } = useSelector((state: OrangeGlobalState) => state.house);
   const dispatch = useDispatch();
 
-  const onGetHouse = (
-    houseId: number,
-  ) => {
+  const onGetHouse = (houseId: number) => {
     dispatch(houseActions.getHouse(houseId));
   };
 
   useEffect(() => {
     onGetHouse(props.houseId);
-    if (createStatus === necessityStatus.SUCCESS) {
+    if (createPlaceStatus === necessityStatus.SUCCESS) {
       setModalOpen(false);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [createStatus]);
+  }, [createPlaceStatus]);
 
   useEffect(() => {
     houseActions.getHouse(props.houseId);
@@ -55,8 +55,15 @@ function NecessityPage(props: Props) {
       </Modal>
       <div className="placebox-wrapper">
         <h1 className="NecessityPageBlock">{house?.name}</h1>
-        <Slider className="slider" dots slidesToShow={1.6} slidesToScroll={1} infinite={false}>
-          {Boolean(places) && places.map((place) => <PlaceBox place={place} key={place.id} />)}
+        <Slider
+          className="slider"
+          dots
+          slidesToShow={1.6}
+          slidesToScroll={1}
+          infinite={false}
+        >
+          {Boolean(places)
+            && places.map((place) => <PlaceBox place={place} key={place.id} />)}
           <div
             className="create-place-box"
             style={{

--- a/orange/src/store/actions/necessity/necessity.tsx
+++ b/orange/src/store/actions/necessity/necessity.tsx
@@ -12,7 +12,9 @@ const countNecessityPlaceFailure = (error: AxiosError) => {
   switch (error.response?.status) {
     default:
       actionType = necessityConstants.COUNT_NECESSITYPLACE_FAILURE;
-      alert(`Necessity 수량 변경에 실패했어요ㅠㅠ\n 에러 메시지 : ${error.response?.status}`);
+      alert(
+        `Necessity 수량 변경에 실패했어요ㅠㅠ\n 에러 메시지 : ${error.response?.status}`,
+      );
       break;
   }
   return {
@@ -21,18 +23,19 @@ const countNecessityPlaceFailure = (error: AxiosError) => {
   };
 };
 export const countNecessityPlace = (
-  placeId: number, necessityId: number, count: number,
-) => (dispatch: Dispatch) => axios.put(`/api/v1/place/${placeId}/necessity/${necessityId}/count/`, { count })
+  placeId: number,
+  necessityId: number,
+  count: number,
+) => (dispatch: Dispatch) => axios
+  .put(`/api/v1/place/${placeId}/necessity/${necessityId}/count/`, { count })
   .then((countNecessityPlaceResponse: AxiosResponse<Necessity>) => {
     dispatch(countNecessityPlaceSuccess(countNecessityPlaceResponse.data));
   })
-  .catch((countNecessityPlaceError) => dispatch(
-    countNecessityPlaceFailure(countNecessityPlaceError),
-  ));
+  .catch((countNecessityPlaceError) => dispatch(countNecessityPlaceFailure(countNecessityPlaceError)));
 
-const createPlaceSuccess = (place: Place) => ({
+const createPlaceSuccess = (places: Array<Place>) => ({
   type: necessityConstants.CREATE_PLACE_SUCCESS,
-  target: place,
+  target: places,
 });
 const createPlaceFailure = (error: AxiosError) => {
   let actionType = null;
@@ -43,7 +46,9 @@ const createPlaceFailure = (error: AxiosError) => {
       break;
     default:
       actionType = necessityConstants.CREATE_PLACE_FAILURE;
-      alert(`Place 생성에 실패했어요ㅠㅠ\n 에러 메시지 : ${error.response?.status}`);
+      alert(
+        `Place 생성에 실패했어요ㅠㅠ\n 에러 메시지 : ${error.response?.status}`,
+      );
       break;
   }
   return {
@@ -51,10 +56,11 @@ const createPlaceFailure = (error: AxiosError) => {
     target: error,
   };
 };
-export const createPlace = (
-  houseId: number, name: string,
-) => (dispatch: Dispatch) => axios.post(`/api/v1/house/${houseId}/place/`, { name })
-  .then((createPlaceResponse: AxiosResponse<Place>) => {
+export const createPlace = (houseId: number, name: string) => (
+  dispatch: Dispatch,
+) => axios
+  .post(`/api/v1/house/${houseId}/place/`, { name })
+  .then((createPlaceResponse: AxiosResponse<[Place]>) => {
     dispatch(createPlaceSuccess(createPlaceResponse.data));
   })
   .catch((createPlaceError) => dispatch(createPlaceFailure(createPlaceError)));
@@ -72,7 +78,9 @@ const createNecessityPlaceFailure = (error: AxiosError) => {
       break;
     default:
       actionType = necessityConstants.CREATE_NECESSITYPLACE_FAILURE;
-      alert(`Necessity 생성에 실패했어요ㅠㅠ\n 에러 메시지 : ${error.response?.status}`);
+      alert(
+        `Necessity 생성에 실패했어요ㅠㅠ\n 에러 메시지 : ${error.response?.status}`,
+      );
   }
   return {
     type: actionType,
@@ -80,16 +88,25 @@ const createNecessityPlaceFailure = (error: AxiosError) => {
   };
 };
 export const createNecessityPlace = (
-  placeId: number, name: string, option: string, description: string, price: number, count: number,
-) => (dispatch: Dispatch) => axios.post(`/api/v1/place/${placeId}/necessity/`, {
-  placeId, name, option, description, price, count,
-})
+  placeId: number,
+  name: string,
+  option: string,
+  description: string,
+  price: number,
+  count: number,
+) => (dispatch: Dispatch) => axios
+  .post(`/api/v1/place/${placeId}/necessity/`, {
+    placeId,
+    name,
+    option,
+    description,
+    price,
+    count,
+  })
   .then((createNecessityPlaceResponse: AxiosResponse<Place>) => {
     dispatch(createNecessityPlaceSuccess(createNecessityPlaceResponse.data));
   })
-  .catch((createNecessityPlaceError) => dispatch(
-    createNecessityPlaceFailure(createNecessityPlaceError),
-  ));
+  .catch((createNecessityPlaceError) => dispatch(createNecessityPlaceFailure(createNecessityPlaceError)));
 
 const removePlaceSuccess = (places: Array<Place>) => ({
   type: necessityConstants.REMOVE_PLACE_SUCCESS,
@@ -112,7 +129,9 @@ const removePlaceFailure = (error: AxiosError) => {
       break;
     default:
       actionType = necessityConstants.REMOVE_PLACE_FAILURE;
-      alert(`Place 삭제에 실패했어요ㅠㅠ\n 에러 메시지 : ${error.response?.status}`);
+      alert(
+        `Place 삭제에 실패했어요ㅠㅠ\n 에러 메시지 : ${error.response?.status}`,
+      );
       break;
   }
   return {
@@ -120,14 +139,11 @@ const removePlaceFailure = (error: AxiosError) => {
     target: error,
   };
 };
-export const removePlace = (
-  houseId: number, placeId: number,
-) => (dispatch: Dispatch) => axios.delete(
-  `/api/v1/house/${houseId}/place/${placeId}/`,
-)
-  .then((removePlaceResponse: AxiosResponse<[Place]>) => dispatch(
-    removePlaceSuccess(removePlaceResponse.data),
-  ))
+export const removePlace = (houseId: number, placeId: number) => (
+  dispatch: Dispatch,
+) => axios
+  .delete(`/api/v1/house/${houseId}/place/${placeId}/`)
+  .then((removePlaceResponse: AxiosResponse<[Place]>) => dispatch(removePlaceSuccess(removePlaceResponse.data)))
   .catch((removePlaceError) => dispatch(removePlaceFailure(removePlaceError)));
 
 const removeNecessityPlaceSuccess = (place: Place) => {
@@ -142,7 +158,9 @@ const removeNecessityPlaceFailure = (error: AxiosError) => {
   switch (error.response?.status) {
     default:
       actionType = necessityConstants.REMOVE_NECESSITYPLACE_FAILURE;
-      alert(`Necessity 삭제에 실패했어요ㅠㅠ\n 에러 메시지 : ${error.response?.status}`);
+      alert(
+        `Necessity 삭제에 실패했어요ㅠㅠ\n 에러 메시지 : ${error.response?.status}`,
+      );
       break;
   }
   return {
@@ -150,16 +168,15 @@ const removeNecessityPlaceFailure = (error: AxiosError) => {
     target: error,
   };
 };
-export const removeNecessityPlace = (
-  placeId: number, necessityId: number,
-) => (dispatch: Dispatch) => axios.delete(`/api/v1/place/${placeId}/necessity/${necessityId}/`)
+export const removeNecessityPlace = (placeId: number, necessityId: number) => (
+  dispatch: Dispatch,
+) => axios
+  .delete(`/api/v1/place/${placeId}/necessity/${necessityId}/`)
   .then((removeNecessityPlaceResponse: AxiosResponse<Place>) => {
     dispatch(removeNecessityPlaceSuccess(removeNecessityPlaceResponse.data));
   })
   .catch((removeNecessityPlaceError) => {
-    dispatch(
-      removeNecessityPlaceFailure(removeNecessityPlaceError),
-    );
+    dispatch(removeNecessityPlaceFailure(removeNecessityPlaceError));
   });
 
 const renamePlaceSuccess = (place: Place) => ({
@@ -179,7 +196,9 @@ const renamePlaceFailure = (error: AxiosError) => {
       break;
     default:
       actionType = necessityConstants.RENAME_PLACE_FAILURE;
-      alert(`Place 이름 수정에 실패했어요ㅠㅠ\n 에러 메시지 : ${error.response?.status}`);
+      alert(
+        `Place 이름 수정에 실패했어요ㅠㅠ\n 에러 메시지 : ${error.response?.status}`,
+      );
       break;
   }
   return {
@@ -187,14 +206,15 @@ const renamePlaceFailure = (error: AxiosError) => {
     target: error,
   };
 };
-export const renamePlace = (
-  houseId: number, placeId: number, name: string,
-) => (dispatch: Dispatch) => axios.put(
-  `/api/v1/house/${houseId}/place/${placeId}/`, { houseId, placeId, name },
-)
-  .then((renamePlaceResponse: AxiosResponse<Place>) => dispatch(
-    renamePlaceSuccess(renamePlaceResponse.data),
-  ))
+export const renamePlace = (houseId: number, placeId: number, name: string) => (
+  dispatch: Dispatch,
+) => axios
+  .put(`/api/v1/house/${houseId}/place/${placeId}/`, {
+    houseId,
+    placeId,
+    name,
+  })
+  .then((renamePlaceResponse: AxiosResponse<Place>) => dispatch(renamePlaceSuccess(renamePlaceResponse.data)))
   .catch((renamePlaceError) => dispatch(renamePlaceFailure(renamePlaceError)));
 
 const updateNecessityPlaceSuccess = (necessity: Necessity) => ({
@@ -209,7 +229,9 @@ const updateNecessityPlaceFailure = (error: AxiosError) => {
       break;
     default:
       actionType = necessityConstants.UPDATE_NECESSITYPLACE_FAILURE;
-      alert(`Necessity 수정에 실패했어요ㅠㅠ\n 에러 메시지 : ${error.response?.status}`);
+      alert(
+        `Necessity 수정에 실패했어요ㅠㅠ\n 에러 메시지 : ${error.response?.status}`,
+      );
       break;
   }
   return {
@@ -218,11 +240,18 @@ const updateNecessityPlaceFailure = (error: AxiosError) => {
   };
 };
 export const updateNecessityPlace = (
-  placeId: number, necessityId: number, description: string, price?: number, count?: number,
-) => (dispatch: Dispatch) => axios.put(`/api/v1/place/${placeId}/necessity/${necessityId}/`, { description, price, count })
+  placeId: number,
+  necessityId: number,
+  description: string,
+  price?: number,
+  count?: number,
+) => (dispatch: Dispatch) => axios
+  .put(`/api/v1/place/${placeId}/necessity/${necessityId}/`, {
+    description,
+    price,
+    count,
+  })
   .then((updateNecessityPlaceResponse: AxiosResponse<Necessity>) => {
     dispatch(updateNecessityPlaceSuccess(updateNecessityPlaceResponse.data));
   })
-  .catch((updateNecessityPlaceError) => dispatch(
-    updateNecessityPlaceFailure(updateNecessityPlaceError),
-  ));
+  .catch((updateNecessityPlaceError) => dispatch(updateNecessityPlaceFailure(updateNecessityPlaceError)));

--- a/orange/src/store/reducers/necessity/necessity.tsx
+++ b/orange/src/store/reducers/necessity/necessity.tsx
@@ -1,8 +1,6 @@
 import { necessityConstants } from '../../actions/actionTypes';
 import { necessityStatus } from '../../../constants/constants';
-import {
-  House, Necessity, Place,
-} from '../../../api';
+import { House, Necessity, Place } from '../../../api';
 import { NecessityState } from '../../state';
 
 type Action = {
@@ -16,6 +14,7 @@ const initialState: NecessityState = {
   removeStatus: necessityStatus.NONE,
   countStatus: necessityStatus.NONE,
   updateStatus: necessityStatus.NONE,
+  createPlaceStatus: necessityStatus.NONE,
   updatePlaceStatus: necessityStatus.NONE,
   removePlaceStatus: necessityStatus.NONE,
   places: [],
@@ -34,7 +33,10 @@ const NecessityResponseCases = [
   necessityConstants.UPDATE_NECESSITYPLACE_SUCCESS,
 ];
 
-function necessityReducer(state = initialState, action: Action): NecessityState {
+function necessityReducer(
+  state = initialState,
+  action: Action,
+): NecessityState {
   if (action.type === necessityConstants.GET_HOUSE_SUCCESS) {
     const house = action.target as House;
     return {
@@ -53,12 +55,19 @@ function necessityReducer(state = initialState, action: Action): NecessityState 
         places,
       };
     }
+    if (action.type === necessityConstants.CREATE_PLACE_SUCCESS) {
+      const places = action.target as Place[];
+      return {
+        ...state,
+        createPlaceStatus: necessityStatus.SUCCESS,
+        places,
+      };
+    }
+
     let { places } = state;
     const data = action.target as Place;
     places = places.map((place) => (place.id === data.id ? data : place));
-
-    if (action.type === necessityConstants.CREATE_NECESSITYPLACE_SUCCESS
-      || action.type === necessityConstants.CREATE_PLACE_SUCCESS) {
+    if (action.type === necessityConstants.CREATE_NECESSITYPLACE_SUCCESS) {
       return {
         ...state,
         createStatus: necessityStatus.SUCCESS,
@@ -90,8 +99,8 @@ function necessityReducer(state = initialState, action: Action): NecessityState 
     places = places.map((place) => {
       if (place.id === data.place_id) {
         const newPlace = place;
-        newPlace.necessities = place.necessities?.map((necessity) => (
-          necessity.id === data.id ? data : necessity));
+        newPlace.necessities = place.necessities?.map((necessity) => (necessity.id === data.id ? data : necessity)
+        );
         return newPlace;
       }
       return place;
@@ -124,16 +133,24 @@ function necessityReducer(state = initialState, action: Action): NecessityState 
       };
 
     case necessityConstants.CREATE_NECESSITYPLACE_FAILURE:
-    case necessityConstants.CREATE_PLACE_FAILURE:
       return {
         ...state,
         createStatus: necessityStatus.FAILURE,
       };
+    case necessityConstants.CREATE_PLACE_FAILURE:
+      return {
+        ...state,
+        createPlaceStatus: necessityStatus.FAILURE,
+      };
     case necessityConstants.CREATE_NECESSITYPLACE_FAILURE_NAME:
-    case necessityConstants.CREATE_PLACE_FAILURE_NAME:
       return {
         ...state,
         createStatus: necessityStatus.FAILURE_NAME,
+      };
+    case necessityConstants.CREATE_PLACE_FAILURE_NAME:
+      return {
+        ...state,
+        createPlaceStatus: necessityStatus.FAILURE_NAME,
       };
 
     case necessityConstants.REMOVE_NECESSITYPLACE_FAILURE:

--- a/orange/src/store/state.ts
+++ b/orange/src/store/state.ts
@@ -9,6 +9,7 @@ export interface NecessityState {
   removeStatus: string;
   countStatus: string;
   updateStatus: string;
+  createPlaceStatus: string;
   updatePlaceStatus: string;
   removePlaceStatus: string;
   places: Place[];


### PR DESCRIPTION
related issues: https://orangenongjang.atlassian.net/browse/ON-80

# Major Changes
## 1. Place 반복 생성하면 추가된 Place가 바로 렌더링되지 않는 문제 해결
- Create Place API 이후 GET House API를 호출함으로써 새로 추가된 Place를 포함해 Place의 array를 받아오는 식으로 처리되고 있었는데, GET House API가 호출되는 부분이 [createStatus에 의존하는 useEffect](https://github.com/gongmyeong-study/orangenongjang/blob/ed30666ad57ac2dfe8157a2dbbdc224e72de1de3/orange/src/containers/NecessityPage/NecessityPage.tsx#L40)에 있고, 이것이 호출되지 않는 고질적 문제([참고 Slack thread](https://gongmyeongstudy.slack.com/archives/C011CSJ7YBH/p1613817763002800?thread_ts=1613817628.002500&cid=C011CSJ7YBH))로 인해 추가된 Place를 새로 가져오지도 못하는 것이었음.
- 위에서 언급한, redux의 000Status에 의존하는 useEffect가 반복 수행시 호출되지 않는(예를 들어 반복 성공해서 createStatus가 "SUCCESS"로 그대로면 바뀌지 않은 것이므로) 문제는 고질적이고 다른 곳에도 퍼져있던 기존 이슈라 일단 냅두고, Create Place API의 response를 해당 House의 모든 Place array를 가져오는 것으로 바꾸어, 설령 modal은 안 닫혀도 뒤에 Place는 항상 새로 추가된 것을 포함해 최신화된 렌더링이 가능하도록 함

# Minor Changes
## 1. necessity reducer에서 NecessityPlace가 생성될 때, Place가 생성될 때 모두 createStatus가 혼용되던 부분을 분리
- 사실 이슈 해결에 무관하지만 좋지 못해서 분리시켜둠. 그렇다고 위에서 언급한 기존의 만연한 modal 이슈가 해결된 것은 아님.
