### PR TITLE
ON-120 [front] House List에서 자신이 Leader인 House에 왕관표시하기

### DIFF
--- a/orange/src/components/Header/Header.tsx
+++ b/orange/src/components/Header/Header.tsx
@@ -109,7 +109,7 @@ class Header extends Component<Props, State> {
     if (this.props.pathname !== '/intro' && this.props.pathname !== '/info') {
       helloUser = (
         <p className="hello-user only-on-desktop">
-          {this.props.me.username}
+          <strong>{this.props.me.username}</strong>
           님 안녕하세요!&nbsp;&nbsp;
         </p>
       );

--- a/orange/src/containers/HousePage/HousePage.scss
+++ b/orange/src/containers/HousePage/HousePage.scss
@@ -92,6 +92,10 @@ button {
         display: flex;
         margin: 10px 0px 0px 5px;
 
+        .house-name-with-crown {
+          display:flex;
+        }
+
         .house-name-update-box {
           display: flex;
 
@@ -230,6 +234,13 @@ button {
     bottom: 0;
     display: flex;
     background: rgba(0, 0, 0, 0.5);
+  }
+
+  .house-intro {
+    position: absolute;
+    display: flex;
+    width: 250px;
+    margin: 10px 0px 0px 5px;
   }
 }
 

--- a/orange/src/containers/HousePage/HousePage.tsx
+++ b/orange/src/containers/HousePage/HousePage.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
 import React, { useEffect, useState } from 'react';
 import EdiText from 'react-editext';
+import { AiFillCrown } from 'react-icons/ai';
 import { useDispatch, useSelector } from 'react-redux';
 import axios from 'axios';
 import { History } from 'history';
@@ -97,29 +98,33 @@ function HousePage(props: Props) {
             {house.users.map((user) => (
               user.username === me.username && user.is_leader)).includes(true)
               ? (
-                <EdiText
-                  viewContainerClassName="house-name-update-box"
-                  editButtonContent={<i className="fas fa-pencil-alt" />}
-                  saveButtonContent={<i className="fas fa-check" />}
-                  cancelButtonContent={<i className="fas fa-times" />}
-                  hideIcons
-                  type="text"
-                  showButtonsOnHover
-                  submitOnUnfocus
-                  submitOnEnter
-                  cancelOnEscape
-                  inputProps={{
-                    className: 'house-name-update-input',
-                    placeholder: 'House 이름을 입력하세요.',
-                    style: { fontSize: 18 },
-                  }}
-                  validationMessage="한 글자 이상, 열 글자 이하로 입력하세요."
-                  validation={(val) => (val.length > 0 && val.length <= 10)}
-                  value={house.name}
-                  onSave={(houseName: string) => {
-                    onRenameHouse(house.id, houseName);
-                  }}
-                />
+                <div className="house-name-with-crown">
+                  <AiFillCrown />
+                  &emsp;
+                  <EdiText
+                    viewContainerClassName="house-name-update-box"
+                    editButtonContent={<i className="fas fa-pencil-alt" />}
+                    saveButtonContent={<i className="fas fa-check" />}
+                    cancelButtonContent={<i className="fas fa-times" />}
+                    hideIcons
+                    type="text"
+                    showButtonsOnHover
+                    submitOnUnfocus
+                    submitOnEnter
+                    cancelOnEscape
+                    inputProps={{
+                      className: 'house-name-update-input',
+                      placeholder: 'House 이름을 입력하세요.',
+                      style: { fontSize: 18 },
+                    }}
+                    validationMessage="한 글자 이상, 열 글자 이하로 입력하세요."
+                    validation={(val) => (val.length > 0 && val.length <= 10)}
+                    value={house.name}
+                    onSave={(houseName: string) => {
+                      onRenameHouse(house.id, houseName);
+                    }}
+                  />
+                </div>
               )
               : house.name}
           </h1>


### PR DESCRIPTION
> Jira [ON-120](https://orangenongjang.atlassian.net/browse/ON-120)

# Major Changes
- House List에서 자신이 Leader인 House에 **왕관** 표시

- Mobile에서 House 소개가 긴 경우 관리 버튼이 클릭되지 않던 문제 해결 (800px 이하인 화면에서 House-intro **width 조절**)

- PC : 
<img width="1792" alt="스크린샷 2021-02-22 오후 2 52 25" src="https://user-images.githubusercontent.com/46114393/108674484-b02fdb00-7528-11eb-8f1c-bc901e78d73f.png">

- Mobile :
<img width="1792" alt="스크린샷 2021-02-22 오후 2 52 31" src="https://user-images.githubusercontent.com/46114393/108674489-b3c36200-7528-11eb-9cb4-71cf2f2e9751.png">


<br>

## Minor Changes
- `{username}님 안녕하세요!` 인삿말에서 {username}을 bold 처리함