### PR TITLE
ON-135 [back] 회원가입 인증 메일에 이름 및 이메일 정보를 수집한다는 내용을 추가

### DIFF
--- a/nongjang/user/text.py
+++ b/nongjang/user/text.py
@@ -11,4 +11,10 @@ def user_invite_message(domain, uidb64, token, user):
            f"오렌지농장에 오신 것을 환영합니다 :)</span> <br><br><br>" \
            f"<h2> From. 오렌지농장(orangenongjang)</h2>" \
            f"<img src='https://orangenongjang-static.s3.ap-northeast-2.amazonaws.com/image/orangenongjang_logo_2.png'" \
-           f"alt='Orangenongjang_logo' width='550' height='500'>"
+           f"alt='Orangenongjang_logo' width='550' height='500'> <br><br>" \
+           f" <span style='font-size: 12px'> <strong>오렌지농장</strong> 은 다음과 같이 귀하의 개인정보를 수집, 이용합니다. <br><br>" \
+           f" □ 개인정보의 수집 및 이용 목적  <br>" \
+           f" 오렌지농장 이용자에 회원인증 메일 및 집 초대장 메일 전송  <br><br>" \
+           f" □ 수집하는 개인정보의 항목  <br>" \
+           f" 필수정보 : 사용자 이름, E-Mail 주소  <br><br>" \
+           f" * 귀하는 위와 관련된 동의를 거부할 권리가 있으나, 필수정보 수집에 동의하지 않는 경우 오렌지농장 서비스 이용이 제한됩니다. </span><br>"


### PR DESCRIPTION
> Jira [ON-135](https://orangenongjang.atlassian.net/browse/ON-135)

# Major Change
- 회원가입 인증 메일에 이름 및 이메일 정보를 수집한다는 다음의 내용을 추가

```
오렌지농장 은 다음과 같이 귀하의 개인정보를 수집, 이용합니다.

□ 개인정보의 수집 및 이용 목적
오렌지농장 이용자에 회원인증 메일 및 집 초대장 메일 전송

□ 수집하는 개인정보의 항목
필수정보 : 사용자 이름, E-Mail 주소

* 귀하는 위와 관련된 동의를 거부할 권리가 있으나, 필수정보 수집에 동의하지 않는 경우 오렌지농장 서비스 이용이 제한됩니다.
```
<img width="533" alt="image" src="https://user-images.githubusercontent.com/46114393/110353310-419b6300-807a-11eb-9cff-f8d765907f03.png">

<br>
