### PR TITLE
ON-136 [front] House Modal에서 집 이름/소개 수정 시 HouseList 최신화

### DIFF
--- a/orange/src/App.test.tsx
+++ b/orange/src/App.test.tsx
@@ -12,6 +12,8 @@ const mockStore = getMockStore({
   necessity: {
     necessities: [],
   },
+  house: {
+  },
 });
 
 test('renders app with mock store', () => {

--- a/orange/src/containers/HousePage/HousePage.tsx
+++ b/orange/src/containers/HousePage/HousePage.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable jsx-a11y/anchor-is-valid */
 import axios from 'axios';
 import React, { useEffect, useState } from 'react';
 import { AiFillCrown } from 'react-icons/ai';
@@ -8,6 +7,7 @@ import Modal from 'react-modal';
 
 import { House, User } from '../../api';
 import { HouseCreateForm, HouseInviteModal, HouseManageModal } from '../../components';
+import { houseStatus } from '../../constants/constants';
 import { userActions } from '../../store/actions/index';
 import { OrangeGlobalState } from '../../store/state';
 
@@ -26,7 +26,14 @@ function HousePage(props: Props) {
   const [isCreateHouseModalOpen, setIsCreateHouseModalOpen] = useState(false);
   const [houseToBeManaged, setHouseToBeManaged] = useState<House>();
   const [houseToBeInvited, setHouseToBeInvited] = useState<House>();
-  const { getMeStatus, me } = useSelector((state: OrangeGlobalState) => state.user);
+  const {
+    getMeStatus, me, reintroduceHouseStatus, renameHouseStatus,
+  } = useSelector((state: OrangeGlobalState) => ({
+    getMeStatus: state.user.getMeStatus,
+    me: state.user.me,
+    reintroduceHouseStatus: state.house.reintroduceHouseStatus,
+    renameHouseStatus: state.house.renameHouseStatus,
+  }));
 
   const manageHouse = (e: any, house: House) => {
     e.stopPropagation();
@@ -64,6 +71,14 @@ function HousePage(props: Props) {
   useEffect(() => {
     userActions.getMe();
   }, [getMeStatus]);
+
+  useEffect(() => {
+    if (reintroduceHouseStatus === houseStatus.SUCCESS
+      || renameHouseStatus === houseStatus.SUCCESS) {
+      axios.get('/api/v1/house/')
+        .then((res) => setHouses(res.data));
+    }
+  }, [reintroduceHouseStatus, renameHouseStatus]);
 
   const goToTheRoom = (houseId: number) => {
     const url = `/main/${houseId}`;

--- a/orange/src/tests/mocks.tsx
+++ b/orange/src/tests/mocks.tsx
@@ -19,10 +19,12 @@ export const middlewares = [thunk, routerMiddleware(history)];
 export const getMockStore = (initialState: any) => {
   const mockUserReducer = getMockReducer(initialState.user);
   const mockNecessityReducer = getMockReducer(initialState.necessity);
+  const mockHouseReducer = getMockReducer(initialState.house);
   const rootReducer = (his: any) => combineReducers({
     router: connectRouter(his),
     user: mockUserReducer,
     necessity: mockNecessityReducer,
+    house: mockHouseReducer,
   });
 
   const mockStore = createStore(rootReducer(history), applyMiddleware(...middlewares));


### PR DESCRIPTION
> Jira [ON-136](https://orangenongjang.atlassian.net/browse/ON-136)

# Major Changes
### 1. House 정보 변경 시 status 재호출
- `reintroduceHouseStatus`, `renameHouseStatus`를 사용하여 수정 modal 밖의 페이지에도 연동되도록 수정.

<br>

### 2. App test 일부 수정
- `getMockReducer`에 `mockHouseReducer` 추가

<br>
